### PR TITLE
Update docker image tag and refine content in dockerfile README.md

### DIFF
--- a/dockerfile/README.md
+++ b/dockerfile/README.md
@@ -1,34 +1,33 @@
-# Dockerfile for WSO2 Identity Server #
+# Dockerfile for WSO2 Identity Server
 The Dockerfile defines the resources and instructions to build the Docker image for WSO2 Identity Server 5.3.0.
 
 ## Build and run
-Steps to build the WSO2 Identity Server 5.3.0 docker image and run in your local machine.
+Follow below steps to build the WSO2 Identity Server 5.3.0 docker image and run in your local machine.
 
 The local copy of the `dockerfile` directory will be referred as `DOCKERFILE_HOME`.
 
-* Add the JDK and WSO2 Identity Server distributions
+* Add the JDK and WSO2 Identity Server distributions:
     - Download JDK 1.8 (http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) and copy it to `<DOCKERFILE_HOME>/files`.
     - Download the WSO2 Identity Server 5.3.0 distribution (https://wso2.com/identity-and-access-management) and copy it to `<DOCKERFILE_HOME>/files`.
-    Please refer [WSO2 Update Manager documentation](https://docs.wso2.com/display/ADMIN44x/Updating+WSO2+Products) to
-    obtained the Identity Server 5.3.0 with latest bug fixes and updates.
+    Please refer [WSO2 Update Manager documentation](https://docs.wso2.com/display/ADMIN44x/Updating+WSO2+Products) to obtain the Identity Server 5.3.0 with latest bug fixes and updates.
 
-* Build the docker image
+* Build the docker image:
     - Navigate to `<DOCKERFILE_HOME>` directory.
     - Execute the `docker build` command as shown below;
-        + `docker build -t wso2is-5.3.0 .`
+        + `docker build -t wso2is:5.3.0 .`
 
-* Docker run
+* Docker run:
     - Run the Identity Server 5.3.0 Docker container as follows;
-        + `docker run -it -p 9443:9443 wso2is-5.3.0`
+        + `docker run -it -p 9443:9443 wso2is:5.3.0`
 
-* Access management console
+* Access management console:
     -  To access the management console, use the docker host IP and port 9443.
         + `https:<DOCKER_HOST_IP>:9443/carbon`
 
-## Modify configurations of the Identity Server running in the container
+## How to update configurations
 The configurations will be maintained on the Docker Host machine and volume mounted to the container.
 
-As an example, the steps required to change the port offset in `carbon.xml` is detailed.
+As an example, the steps required to change the port offset in `carbon.xml` is as follows:
 
 * Stop the Identity Server container if it's already running.
 
@@ -44,5 +43,4 @@ As an example, the steps required to change the port offset in `carbon.xml` is d
     - Navigate to `<DOCKERFILE_HOME>` directory.
     - `docker run -it --mount type=bind,source=${PWD}/files/wso2is-5.3.0/repository/conf,target=/home/wso2user/wso2is-5.3.0/repository/conf wso2is-5.3.0`
 
-* If the `conf` directory on the host machine is located on a different directory than shown above, when executing the `docker run`
-command the absolute path of the `conf` directory should be set as the `source`.
+* If the `conf` directory on the host machine is located on a different directory than shown above, when executing the `docker run` command the absolute path of the `conf` directory should be set as the `source`.


### PR DESCRIPTION
## Purpose
Change docker image tag from wso2is-5.3.0 to wso2is:5.3.0 and refine content in the IS Dockerfile README.md file.