### PR TITLE
Define user id and group id for non-root users in Dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
-# WSO2 Identity Server Docker Resources
+# Docker Resources for WSO2 Identity Server
 
 This repository contains following Docker resources:
 
-- Identity Server Dockerfile
-- Identity Server Docker Compose Templates
+- WSO2 Identity Server Dockerfile
+- WSO2 Identity Server Analytics Dockerfile
+- Docker Compose files to evaluate most common deployment profiles
 
-The Identity Server Dockerfile builds a generic Docker image for deploying Identity Server in containerized environments. It includes the JDK, product distribution and a collection of utility libraries. Configurations, JDBC driver, extensions and other deployable artifacts are designed to be provided via volume mounts.
+The Identity Server and Identity Server Analytics Dockerfiles build generic Docker images for deploying Identity Server and
+Identity Server Analytics in containerized environments. It includes the JDK, product distributions and a collection of utility
+libraries. Configurations, JDBC driver, extensions and other deployable artifacts are designed to be provided via Docker volume mounts.
 
-The Docker Compose templates have been created according to standard Identity Server deployment patterns for allowing users to evaluate the product and understand the deployment architecture in depth. The Docker Compose templates make use of the Identity Server Docker image, Identity Server Analytics Docker image, MySQL Docker image and HAProxy Docker image.
+Docker Compose file has been created according to most common Identity Server deployment profiles for allowing users to evaluate
+product features to meet their co-operate identity and access management requirements. The Docker Compose files make use of the
+per-profile Docker images of WSO2 Identity Server and Identity Server Analytics and MySQL Docker image.

--- a/dockerfiles/is-analytics/Dockerfile
+++ b/dockerfiles/is-analytics/Dockerfile
@@ -22,7 +22,9 @@ MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations
 ARG USER=wso2carbon
+ARG USER_ID=802
 ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
@@ -45,8 +47,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # create a user group and a user
-RUN groupadd --system ${USER_GROUP} && \
-    useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP} ${USER}
+RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
+    useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
 
 # copy the jdk and wso2 product distribution zip files to user's home directory
 COPY ${FILES}/${JDK_ARCHIVE} ${FILES}/${WSO2_SERVER_PACK} ${USER_HOME}/
@@ -61,7 +63,7 @@ RUN mkdir -p ${JAVA_HOME} && \
     chmod -R g=u ${USER_HOME}
 
 # set the user and work directory
-USER ${USER}
+USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables

--- a/dockerfiles/is/Dockerfile
+++ b/dockerfiles/is/Dockerfile
@@ -22,7 +22,9 @@ MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations
 ARG USER=wso2carbon
+ARG USER_ID=802
 ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
@@ -45,8 +47,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # create a user group and a user
-RUN groupadd --system ${USER_GROUP} && \
-    useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP} ${USER}
+RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
+    useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
 
 # copy the jdk and wso2 product distribution zip files to user's home directory
 COPY ${FILES}/${JDK_ARCHIVE} ${FILES}/${WSO2_SERVER_PACK} ${USER_HOME}/
@@ -61,7 +63,7 @@ RUN mkdir -p ${JAVA_HOME} && \
     chmod -R g=u ${USER_HOME}
 
 # set the user and work directory
-USER ${USER}
+USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables


### PR DESCRIPTION
## Purpose
> It is required to define user id and group id for the non-root user in a Dockerfile for permission management during volume mounting from Docker host to containers. In addition, the README.md files required refinements. This resolves https://github.com/wso2/docker-is/issues/31.

## Goals
> Introduce user id and group id for the non-root user in Dockerfiles and refine README.md documentation.