### PR TITLE
Increase mysql health check interval in docker-compose 

### DIFF
--- a/docker-compose/is-analytics/docker-compose.yml
+++ b/docker-compose/is-analytics/docker-compose.yml
@@ -10,49 +10,49 @@ services:
       - ./mysql/scripts:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-uroot", "-pwso2carbon"]
-      interval: 5s
+      interval: 30s
       timeout: 60s
-
+      retries: 5
   identity-server-analytics:
-      image: wso2is-analytics:5.3.0
-      ports:
-        - "9444:9444"
-        - "9764:9764"
-      healthcheck:
-        test: ["CMD", "curl", "-k", "-f", "https://localhost:9444/carbon/admin/login.jsp"]
-        interval: 10s
-        timeout: 120s
-        retries: 5
-      depends_on:
-        mysql:
-          condition: service_healthy
-      volumes:
-        - ./identity-server-analytics/repository/components/lib/mysql-connector-java-5.1.35-bin.jar:/home/wso2carbon/wso2is-analytics-5.3.0/repository/components/lib/mysql-connector-java-5.1.35-bin.jar
-        - ./identity-server-analytics/repository/conf/user-mgt.xml:/home/wso2carbon/wso2is-analytics-5.3.0/repository/conf/user-mgt.xml
-        - ./identity-server-analytics/repository/conf/datasources/master-datasources.xml:/home/wso2carbon/wso2is-analytics-5.3.0/repository/conf/datasources/master-datasources.xml
-        - ./identity-server-analytics/repository/conf/carbon.xml:/home/wso2carbon/wso2is-analytics-5.3.0/repository/conf/carbon.xml
-      links:
-        - mysql
+    image: wso2is-analytics:5.3.0
+    ports:
+      - "9444:9444"
+      - "9764:9764"
+    healthcheck:
+      test: ["CMD", "curl", "-k", "-f", "https://localhost:9444/carbon/admin/login.jsp"]
+      interval: 10s
+      timeout: 120s
+      retries: 5
+    depends_on:
+      mysql:
+        condition: service_healthy
+    volumes:
+      - ./identity-server-analytics/repository/components/lib/mysql-connector-java-5.1.35-bin.jar:/home/wso2carbon/wso2is-analytics-5.3.0/repository/components/lib/mysql-connector-java-5.1.35-bin.jar
+      - ./identity-server-analytics/repository/conf/user-mgt.xml:/home/wso2carbon/wso2is-analytics-5.3.0/repository/conf/user-mgt.xml
+      - ./identity-server-analytics/repository/conf/datasources/master-datasources.xml:/home/wso2carbon/wso2is-analytics-5.3.0/repository/conf/datasources/master-datasources.xml
+      - ./identity-server-analytics/repository/conf/carbon.xml:/home/wso2carbon/wso2is-analytics-5.3.0/repository/conf/carbon.xml
+    links:
+      - mysql
   identity-server:
     image: wso2is:5.3.0
     ports:
       - "9763:9763"
       - "9443:9443"
     healthcheck:
-        test: ["CMD", "curl", "-k", "-f", "https://localhost:9443/carbon/admin/login.jsp"]
-        interval: 5s
-        timeout: 120s
-        start_period: 120s
+      test: ["CMD", "curl", "-k", "-f", "https://localhost:9443/carbon/admin/login.jsp"]
+      interval: 5s
+      timeout: 120s
+      start_period: 120s
     volumes:
-        - ./identity-server/repository/components/lib/mysql-connector-java-5.1.35-bin.jar:/home/wso2carbon/wso2is-5.3.0/repository/components/lib/mysql-connector-java-5.1.35-bin.jar
-        - ./identity-server/repository/conf/carbon.xml:/home/wso2carbon/wso2is-5.3.0/repository/conf/carbon.xml
-        - ./identity-server/repository/conf/user-mgt.xml:/home/wso2carbon/wso2is-5.3.0/repository/conf/user-mgt.xml
-        - ./identity-server/repository/conf/identity/identity.xml:/home/wso2carbon/wso2is-5.3.0/repository/conf/identity/identity.xml
-        - ./identity-server/repository/conf/datasources/master-datasources.xml:/home/wso2carbon/wso2is-5.3.0/repository/conf/datasources/master-datasources.xml
-        - ./identity-server/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-AuthenticationData.xml:/home/wso2carbon/wso2is-5.3.0/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-AuthenticationData.xml
-        - ./identity-server/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-RoleData.xml:/home/wso2carbon/wso2is-5.3.0/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-RoleData.xml
-        - ./identity-server/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-SessionData.xml:/home/wso2carbon/wso2is-5.3.0/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-SessionData.xml
-        - ./identity-server/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-UserData.xml:/home/wso2carbon/wso2is-5.3.0/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-UserData.xml
+      - ./identity-server/repository/components/lib/mysql-connector-java-5.1.35-bin.jar:/home/wso2carbon/wso2is-5.3.0/repository/components/lib/mysql-connector-java-5.1.35-bin.jar
+      - ./identity-server/repository/conf/carbon.xml:/home/wso2carbon/wso2is-5.3.0/repository/conf/carbon.xml
+      - ./identity-server/repository/conf/user-mgt.xml:/home/wso2carbon/wso2is-5.3.0/repository/conf/user-mgt.xml
+      - ./identity-server/repository/conf/identity/identity.xml:/home/wso2carbon/wso2is-5.3.0/repository/conf/identity/identity.xml
+      - ./identity-server/repository/conf/datasources/master-datasources.xml:/home/wso2carbon/wso2is-5.3.0/repository/conf/datasources/master-datasources.xml
+      - ./identity-server/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-AuthenticationData.xml:/home/wso2carbon/wso2is-5.3.0/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-AuthenticationData.xml
+      - ./identity-server/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-RoleData.xml:/home/wso2carbon/wso2is-5.3.0/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-RoleData.xml
+      - ./identity-server/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-SessionData.xml:/home/wso2carbon/wso2is-5.3.0/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-SessionData.xml
+      - ./identity-server/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-UserData.xml:/home/wso2carbon/wso2is-5.3.0/repository/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-UserData.xml
     depends_on:
       identity-server-analytics:
         condition: service_healthy


### PR DESCRIPTION
## Purpose
The `is-analytics` docker compose project fails to start up because the analytics container is spawned before the mysql container is ready. Hence we increase the health check interval for mysql in order to ensure the server is up and also ready to accept connections. Fix #33.

