### PR TITLE
fix IS instructions

### DIFF
--- a/dockerfiles/is/Dockerfile
+++ b/dockerfiles/is/Dockerfile
@@ -61,8 +61,8 @@ COPY --chown=wso2carbon:wso2 ${FILES}/${JDK} ${USER_HOME}/java
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${USER_HOME}/${WSO2_SERVER_PACK}/
 COPY --chown=wso2carbon:wso2 init.sh ${USER_HOME}/
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${USER_HOME}/${WSO2_SERVER_PACK}/repository/components/lib/
-ADD --chown=wso2carbon:wso2 http://www.dnsjava.org/download/dnsjava-2.1.8.jar ${USER_HOME}/${WSO2_SERVER_PACK}/repository/components/lib/
-ADD --chown=wso2carbon:wso2 http://central.maven.org/maven2/org/wso2/carbon/kubernetes/artifacts/kubernetes-membership-scheme/1.0.5/kubernetes-membership-scheme-1.0.5.jar ${USER_HOME}/${WSO2_SERVER_PACK}/repository/components/dropins/
+ADD --chown=wso2carbon:wso2 https://repo1.maven.org/maven2/dnsjava/dnsjava/2.1.8/dnsjava-2.1.8.jar ${USER_HOME}/${WSO2_SERVER_PACK}/repository/components/lib/
+ADD --chown=wso2carbon:wso2 https://repo1.maven.org/maven2/org/wso2/carbon/kubernetes/artifacts/kubernetes-membership-scheme/1.0.5/kubernetes-membership-scheme-1.0.5.jar ${USER_HOME}/${WSO2_SERVER_PACK}/repository/components/dropins/
 # set temporary location for shared artifacts
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/repository/deployment/ ${USER_HOME}/wso2-tmp/deployment
 

--- a/dockerfiles/is/Dockerfile
+++ b/dockerfiles/is/Dockerfile
@@ -61,8 +61,8 @@ COPY --chown=wso2carbon:wso2 ${FILES}/${JDK} ${USER_HOME}/java
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${USER_HOME}/${WSO2_SERVER_PACK}/
 COPY --chown=wso2carbon:wso2 init.sh ${USER_HOME}/
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${USER_HOME}/${WSO2_SERVER_PACK}/repository/components/lib/
-COPY --chown=wso2carbon:wso2 ${FILES}/dnsjava-*.jar ${USER_HOME}/${WSO2_SERVER_PACK}/repository/components/lib/
-COPY --chown=wso2carbon:wso2 ${FILES}/kubernetes-membership-scheme-*.jar ${USER_HOME}/${WSO2_SERVER_PACK}/repository/components/dropins/
+ADD --chown=wso2carbon:wso2 http://www.dnsjava.org/download/dnsjava-2.1.8.jar ${USER_HOME}/${WSO2_SERVER_PACK}/repository/components/lib/
+ADD --chown=wso2carbon:wso2 http://central.maven.org/maven2/org/wso2/carbon/kubernetes/artifacts/kubernetes-membership-scheme/1.0.5/kubernetes-membership-scheme-1.0.5.jar ${USER_HOME}/${WSO2_SERVER_PACK}/repository/components/dropins/
 # set temporary location for shared artifacts
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/repository/deployment/ ${USER_HOME}/wso2-tmp/deployment
 
@@ -77,6 +77,6 @@ ENV JAVA_HOME=${JAVA_HOME} \
     WORKING_DIRECTORY=${USER_HOME}
 
 # expose ports
-EXPOSE 4000 9763 9443 
+EXPOSE 4000 9763 9443
 
 ENTRYPOINT ${WORKING_DIRECTORY}/init.sh

--- a/dockerfiles/is/README.md
+++ b/dockerfiles/is/README.md
@@ -13,17 +13,18 @@ git clone https://github.com/wso2/docker-is.git
 >The local copy of the `dockerfiles/is` directory will be referred to as `IS_DOCKERFILE_HOME` from this point onwards.
 
 ##### 2. Add JDK, WSO2 Identity Server distribution and MySQL connector to `<IS_DOCKERFILE_HOME>/files`
-- Download [JDK 1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+- Download [JDK 1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) `.tar.gz` for Linux x64
 and extract it to `<IS_DOCKERFILE_HOME>/files`.
 - Download the WSO2 Identity Server 5.5.0 distribution (https://wso2.com/identity-and-access-management)
-and extract it to `<IS_DOCKERFILE_HOME>/files`. <br>
-- Once both JDK and WSO2 Identity Server distributions are extracted it may look as follows:
+and extract it to `<IS_DOCKERFILE_HOME>/files`.
+- Download [MySQL Connector/J](https://dev.mysql.com/downloads/connector/j/) v5.1.45, extract it, and copy the `*-bin.jar` to `<IS_DOCKERFILE_HOME>/files`.
+- Once all of these are in place, it should look as follows:
 
   ```bash
   <IS_DOCKERFILE_HOME>/files/jdk<version>/
+  <IS_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.46-bin.jar
   <IS_DOCKERFILE_HOME>/files/wso2is-5.5.0/
   ```
-- Download [MySQL Connector/J](https://dev.mysql.com/downloads/connector/j/) v5.1.45 and then copy that to `<IS_DOCKERFILE_HOME>/files` folder
 >Please refer to [WSO2 Update Manager documentation](https://docs.wso2.com/display/ADMIN44x/Updating+WSO2+Products)
 in order to obtain latest bug fixes and updates for the product.
 
@@ -31,7 +32,7 @@ in order to obtain latest bug fixes and updates for the product.
 - Navigate to `<IS_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
     + `docker build -t wso2is:5.5.0 .`
-    
+
 ##### 4. Running the Docker image.
 - `docker run -it -p 9443:9443 wso2is:5.5.0`
 >Here, only port 9443 (HTTPS servlet transport) has been mapped to a Docker host port.
@@ -40,9 +41,10 @@ You may map other container service ports, which have been exposed to Docker hos
 ##### 6. Accessing management console.
 - To access the management console, use the docker host IP and port 9443.
     + `https://<DOCKER_HOST>:9443/carbon`
-    
+
 >In here, <DOCKER_HOST> refers to hostname or IP of the host machine on top of which containers are spawned.
 
+Log in with username `admin`, password `admin`.
 
 ## How to update configurations
 Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>

--- a/dockerfiles/is/README.md
+++ b/dockerfiles/is/README.md
@@ -22,7 +22,7 @@ and extract it to `<IS_DOCKERFILE_HOME>/files`.
 
   ```bash
   <IS_DOCKERFILE_HOME>/files/jdk<version>/
-  <IS_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.46-bin.jar
+  <IS_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
   <IS_DOCKERFILE_HOME>/files/wso2is-5.5.0/
   ```
 >Please refer to [WSO2 Update Manager documentation](https://docs.wso2.com/display/ADMIN44x/Updating+WSO2+Products)


### PR DESCRIPTION
## Purpose

The setup instructions were incomplete, so clarified them, and adjusted the Dockerfile to not require additional downloads.

## Goals

Have a first-run experience through the IS README without errors.

## Approach

N/A

## User stories

As a user, I want to run the Identity Server through Docker (without having to [sign up for a trial](https://wso2.com/identity-and-access-management/install/download/?type=docker)).

## Release note

* Fixed setup instructions for the Identity Server Docker image

## Documentation

It's in the pull request.

## Training

N/A?

## Certification

N/A

## Marketing

N/A

## Automation tests

N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? no
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

none

## Migrations (if applicable)

none

## Test environment

```
$ ls files
jdk1.8.0_172  mysql-connector-java-5.1.46-bin.jar  wso2is-5.5.0
$ uname -a
Darwin X02R2J-2AAFH05 16.7.0 Darwin Kernel Version 16.7.0: Fri Apr 27 17:59:46 PDT 2018; root:xnu-3789.73.13~1/RELEASE_X86_64 x86_64
$ docker version
Client:
 Version:      18.03.1-ce
 API version:  1.37
 Go version:   go1.9.5
 Git commit:   9ee9f40
 Built:        Thu Apr 26 07:13:02 2018
 OS/Arch:      darwin/amd64
 Experimental: false
 Orchestrator: swarm

Server:
 Engine:
  Version:      18.03.1-ce
  API version:  1.37 (minimum version 1.12)
  Go version:   go1.9.5
  Git commit:   9ee9f40
  Built:        Thu Apr 26 07:22:38 2018
  OS/Arch:      linux/amd64
  Experimental: true
```
 
## Learning

none