### PR TITLE
Add support for a temporary folder in Identity Server Analytics

### DIFF
--- a/dockerfiles/is-analytics/Dockerfile
+++ b/dockerfiles/is-analytics/Dockerfile
@@ -63,6 +63,8 @@ COPY --chown=wso2carbon:wso2 init.sh ${USER_HOME}/
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${USER_HOME}/${WSO2_SERVER_PACK}/repository/components/lib/
 COPY --chown=wso2carbon:wso2 ${FILES}/dnsjava-*.jar ${USER_HOME}/${WSO2_SERVER_PACK}/repository/components/lib/
 COPY --chown=wso2carbon:wso2 ${FILES}/kubernetes-membership-scheme-*.jar ${USER_HOME}/${WSO2_SERVER_PACK}/repository/components/dropins/
+# set temporary location for artifacts to be persisted
+COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/repository/conf/analytics ${USER_HOME}/wso2-tmp/analytics
 
 # set the user and work directory
 USER ${USER_ID}

--- a/dockerfiles/is-analytics/init.sh
+++ b/dockerfiles/is-analytics/init.sh
@@ -26,6 +26,8 @@ group=wso2
 # file path variables
 volumes=${WORKING_DIRECTORY}/wso2-volume
 k8s_volumes=${WORKING_DIRECTORY}/kubernetes-volumes
+temp_persisted_artifacts=${WORKING_DIRECTORY}/wso2-tmp/analytics
+original_persisted_artifacts=${WSO2_SERVER_HOME}/repository/conf/analytics
 
 # capture the Docker container IP from the container's /etc/hosts file
 docker_container_ip=$(awk 'END{print $1}' /etc/hosts)
@@ -35,6 +37,19 @@ test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not 
 
 # check if the WSO2 product home exists
 test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
+
+# copy the backed up artifacts from ${HOME}/wso2-tmp/analytics
+# copying the initial artifacts to ${HOME}/wso2-tmp/analytics was done in the Dockerfile
+# this is to preserve the initial artifacts in a volume mount (the mounted directory can be empty initially)
+# the artifacts will be copied to the <WSO2_SERVER_HOME>/repository/analytics location,
+# before the server is started
+if test -d ${temp_persisted_artifacts}; then
+    if [ -z "$(ls -A ${original_persisted_artifacts}/)" ]; then
+	    # if no artifacts under <WSO2_SERVER_HOME>/repository/deployment/server; copy them
+        echo "Copying shared server artifacts from temporary location to the original server home location..."
+        cp -R ${temp_persisted_artifacts}/* ${original_persisted_artifacts}
+    fi
+fi
 
 # check if any changed configuration files have been mounted, using K8s ConfigMap volumes
 


### PR DESCRIPTION
## Purpose
> It was identified that the content of `<IS_Analytics_Home>/repository/conf/analytics` need to be persisted especially in container cluster management based production setups. Hence, it was decided to introduce a temporary folder which holds the original content of the above mentioned folder, which could be copied into any mounted volume at the container entry point.

## Goals
> Add support for a temporary folder in Identity Server Analytics