### PR TITLE
Add MOTD as an ARG

### DIFF
--- a/dockerfiles/alpine/is-analytics/base/Dockerfile
+++ b/dockerfiles/alpine/is-analytics/base/Dockerfile
@@ -34,7 +34,13 @@ ARG WSO2_SERVER_VERSION=5.7.0
 ARG WSO2_SERVER_PACK=${WSO2_SERVER}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER_PACK}
 ENV ENV=${USER_HOME}"/.ashrc"
-
+# set WSO2 EULA
+ARG MOTD='printf "\n\
+ Welcome to WSO2 Docker Resources \n\
+ --------------------------------- \n\
+ This Docker container comprises of a WSO2 product, running with its latest updates \n\
+ which are under the End User License Agreement (EULA) 2.0. \n\
+ Read more about EULA 2.0 here @ https://wso2.com/licenses/wso2-update/2.0 \n"'
 # install required packages
 RUN  apk add --update --no-cache \
      curl \
@@ -46,12 +52,7 @@ RUN  addgroup -g ${USER_GROUP_ID} ${USER_GROUP}; \
      adduser -u ${USER_ID} -D -g '' -h ${USER_HOME} -G ${USER_GROUP} ${USER} ;
 
 # MOTD login message
-RUN echo 'printf "\n\
-    Welcome to WSO2 Docker Resources \n\
-    --------------------------------- \n\
-    This Docker container comprises of a WSO2 product, running with its latest updates \n\
-    which are under the End User License Agreement (EULA) 2.0. \n\
-    Read more about EULA 2.0 here @ https://wso2.com/licenses/wso2-update/2.0 \n"' > "$ENV"
+RUN echo $MOTD > "$ENV"
 
 # create java prefs dir
 # this is to avoid warning logs printed by FileSystemPreferences class

--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -34,7 +34,13 @@ ARG WSO2_SERVER_VERSION=5.7.0
 ARG WSO2_SERVER_PACK=${WSO2_SERVER}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER_PACK}
 ENV ENV=${USER_HOME}"/.ashrc"
-
+# set WSO2 EULA
+ARG MOTD='printf "\n\
+ Welcome to WSO2 Docker Resources \n\
+ --------------------------------- \n\
+ This Docker container comprises of a WSO2 product, running with its latest updates \n\
+ which are under the End User License Agreement (EULA) 2.0. \n\
+ Read more about EULA 2.0 here @ https://wso2.com/licenses/wso2-update/2.0 \n"'
 # install required packages
 RUN  apk add --update --no-cache \
      curl \
@@ -46,12 +52,7 @@ RUN  addgroup -g ${USER_GROUP_ID} ${USER_GROUP}; \
      adduser -u ${USER_ID} -D -g '' -h ${USER_HOME} -G ${USER_GROUP} ${USER} ;
 
 # MOTD login message
-RUN echo 'printf "\n\
-    Welcome to WSO2 Docker Resources \n\
-    --------------------------------- \n\
-    This Docker container comprises of a WSO2 product, running with its latest updates \n\
-    which are under the End User License Agreement (EULA) 2.0. \n\
-    Read more about EULA 2.0 here @ https://wso2.com/licenses/wso2-update/2.0 \n"' > "$ENV"
+RUN echo $MOTD > "$ENV"
 
 # create java prefs dir
 # this is to avoid warning logs printed by FileSystemPreferences class

--- a/dockerfiles/centos/is-analytics/base/Dockerfile
+++ b/dockerfiles/centos/is-analytics/base/Dockerfile
@@ -36,17 +36,18 @@ ARG WSO2_SERVER=wso2is-analytics
 ARG WSO2_SERVER_VERSION=5.7.0
 ARG WSO2_SERVER_PACK=${WSO2_SERVER}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER_PACK}
-
+# set WSO2 EULA
+ARG MOTD='printf "\n\
+ Welcome to WSO2 Docker Resources \n\
+ --------------------------------- \n\
+ This Docker container comprises of a WSO2 product, running with its latest updates \n\
+ which are under the End User License Agreement (EULA) 2.0. \n\
+ Read more about EULA 2.0 here @ https://wso2.com/licenses/wso2-update/2.0 \n"'
 # install required packages
 RUN yum update -y && \
     yum install -y nc && \
     rm -rf /var/cache/yum/* && \
-    echo 'printf "\n\
-    Welcome to WSO2 Docker Resources \n\
-    --------------------------------- \n\
-    This Docker container comprises of a WSO2 product, running with its latest updates \n\
-    which are under the End User License Agreement (EULA) 2.0. \n\
-    Read more about EULA 2.0 here @ https://wso2.com/licenses/wso2-update/2.0 \n"' > /etc/profile.d/motd.sh
+    echo $MOTD > /etc/profile.d/motd.sh
 
 # create a user group and a user
 RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \

--- a/dockerfiles/centos/is/Dockerfile
+++ b/dockerfiles/centos/is/Dockerfile
@@ -36,17 +36,19 @@ ARG WSO2_SERVER=wso2is
 ARG WSO2_SERVER_VERSION=5.7.0
 ARG WSO2_SERVER_PACK=${WSO2_SERVER}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER_PACK}
+# set WSO2 EULA
+ARG MOTD='printf "\n\
+ Welcome to WSO2 Docker Resources \n\
+ --------------------------------- \n\
+ This Docker container comprises of a WSO2 product, running with its latest updates \n\
+ which are under the End User License Agreement (EULA) 2.0. \n\
+ Read more about EULA 2.0 here @ https://wso2.com/licenses/wso2-update/2.0 \n"'
 
 # install required packages
 RUN yum update -y && \
     yum install -y nc && \
     rm -rf /var/cache/yum/* && \
-    echo 'printf "\n\
-    Welcome to WSO2 Docker Resources \n\
-    --------------------------------- \n\
-    This Docker container comprises of a WSO2 product, running with its latest updates \n\
-    which are under the End User License Agreement (EULA) 2.0. \n\
-    Read more about EULA 2.0 here @ https://wso2.com/licenses/wso2-update/2.0 \n"' > /etc/profile.d/motd.sh
+    echo $MOTD > /etc/profile.d/motd.sh
 
 # create a user group and a user
 RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \

--- a/dockerfiles/ubuntu/is-analytics/base/Dockerfile
+++ b/dockerfiles/ubuntu/is-analytics/base/Dockerfile
@@ -36,7 +36,13 @@ ARG WSO2_SERVER=wso2is-analytics
 ARG WSO2_SERVER_VERSION=5.7.0
 ARG WSO2_SERVER_PACK=${WSO2_SERVER}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER_PACK}
-
+# set WSO2 EULA
+ARG MOTD="\
+Welcome to WSO2 Docker resources.\n\
+------------------------------------ \n\
+The Docker container contains the WSO2 product with its latest updates, which are under the End User License Agreement (EULA) 2.0.\n\
+\n\
+Read more about EULA 2.0 (https://wso2.com/licenses/wso2-update/2.0).\n"
 # install required packages
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -45,13 +51,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
     >> /etc/bash.bashrc \
-    ; echo "\n\
-    Welcome to WSO2 Docker Resources \n\
-    --------------------------------- \n\
-    This Docker container comprises of a WSO2 product, running with its latest updates \n\
-    which are under the End User License Agreement (EULA) 2.0. \n\
-    Read more about EULA 2.0 here @ https://wso2.com/licenses/wso2-update/2.0 \n" \
-    > /etc/motd
+    ; echo "$MOTD"  > /etc/motd
 
 # create a user group and a user
 RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \

--- a/dockerfiles/ubuntu/is-analytics/base/Dockerfile
+++ b/dockerfiles/ubuntu/is-analytics/base/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set to latest Ubuntu LTS
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set to latest Ubuntu LTS
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations
@@ -36,6 +36,13 @@ ARG WSO2_SERVER=wso2is
 ARG WSO2_SERVER_VERSION=5.7.0
 ARG WSO2_SERVER_PACK=${WSO2_SERVER}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER_PACK}
+# set WSO2 EULA
+ARG MOTD="\
+Welcome to WSO2 Docker resources.\n\
+------------------------------------ \n\
+The Docker container contains the WSO2 product with its latest updates, which are under the End User License Agreement (EULA) 2.0.\n\
+\n\
+Read more about EULA 2.0 (https://wso2.com/licenses/wso2-update/2.0).\n"
 
 # install required packages
 RUN apt-get update && \
@@ -45,13 +52,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
     >> /etc/bash.bashrc \
-    ; echo "\n\
-    Welcome to WSO2 Docker Resources \n\
-    --------------------------------- \n\
-    This Docker container comprises of a WSO2 product, running with its latest updates \n\
-    which are under the End User License Agreement (EULA) 2.0. \n\
-    Read more about EULA 2.0 here @ https://wso2.com/licenses/wso2-update/2.0 \n" \
-    > /etc/motd
+    ; echo "$MOTD"  > /etc/motd
 
 # create a user group and a user
 RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \


### PR DESCRIPTION
## Purpose
> Defined MOTD as an ARG with a default message(WUM UPDATED). For a GA build pass MOTD as a build ARG.

Ex: `docker build -t image_name:tag --build-arg MOTD=$MESSAGE .`

fixes #112 
fixes #111 