### PR TITLE
Use AdoptOpenJDK 8 in WSO2 Identity Server and related product Docker resources

### DIFF
--- a/dockerfiles/alpine/is-analytics/README.md
+++ b/dockerfiles/alpine/is-analytics/README.md
@@ -19,7 +19,7 @@ git clone https://github.com/wso2/docker-is.git
 
 >The local copy of the `dockerfile/alpine/is-analytics` directory will be referred to as `ANALYTICS_DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Add WSO2 API Manager Analytics distributions and MySQL Connector to `<ANALYTICS_DOCKERFILE_HOME>/files`.
+##### 2. Add WSO2 Identity Server Analytics distribution and MySQL Connector to `<ANALYTICS_DOCKERFILE_HOME>/files`.
 
 - Download the [WSO2 Identity Server Analytics 5.7.0](https://wso2.com/identity-and-access-management/install/analytics/)
 and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
@@ -27,9 +27,8 @@ and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/jdk<version>/
   <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2am-analytics-5.7.0/
+  <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2is-analytics-5.7.0/
   ```
 
 >Please refer to [WSO2 Update Manager documentation](https://docs.wso2.com/display/WUM300/WSO2+Update+Manager)

--- a/dockerfiles/alpine/is-analytics/README.md
+++ b/dockerfiles/alpine/is-analytics/README.md
@@ -23,11 +23,11 @@ git clone https://github.com/wso2/docker-is.git
 
 - Download the [WSO2 Identity Server Analytics 5.7.0](https://wso2.com/identity-and-access-management/install/analytics/)
 and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) and copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j) and copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
+  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-<version>-bin.jar
   <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2is-analytics-5.7.0/
   ```
 

--- a/dockerfiles/alpine/is-analytics/base/Dockerfile
+++ b/dockerfiles/alpine/is-analytics/base/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set to latest Alpine
-FROM adoptopenjdk/openjdk8:alpine
+FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations

--- a/dockerfiles/alpine/is-analytics/base/Dockerfile
+++ b/dockerfiles/alpine/is-analytics/base/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set to latest Alpine
-FROM openjdk:8u171-jdk-alpine3.8
+FROM adoptopenjdk/openjdk8:alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations
@@ -61,11 +61,10 @@ RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
     chmod -R 755 ${USER_HOME}/.java && \
     chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
-# copy wso2 product distribution zip files to user's home directory and set ownership
+# copy wso2 product distribution zip file to user's home directory and set ownership
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy mysql connector jar to the server as a third party library
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/repository/components/lib/
-ADD --chown=wso2carbon:wso2 https://repo1.maven.org/maven2/org/xerial/snappy/snappy-java/1.1.1.7/snappy-java-1.1.1.7.jar ${WSO2_SERVER_HOME}/repository/components/lib/
 
 # set the user and work directory
 USER ${USER_ID}

--- a/dockerfiles/alpine/is-analytics/base/Dockerfile
+++ b/dockerfiles/alpine/is-analytics/base/Dockerfile
@@ -64,7 +64,7 @@ RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
 # copy wso2 product distribution zip file to user's home directory and set ownership
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy mysql connector jar to the server as a third party library
-COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/repository/components/lib/
+COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib/
 
 # set the user and work directory
 USER ${USER_ID}

--- a/dockerfiles/alpine/is-analytics/dashboard/Dockerfile
+++ b/dockerfiles/alpine/is-analytics/dashboard/Dockerfile
@@ -26,4 +26,4 @@ COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 EXPOSE 9643
 
 # start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/alpine/is-analytics/dashboard/init.sh
+++ b/dockerfiles/alpine/is-analytics/dashboard/init.sh
@@ -69,4 +69,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/dashboard.sh
+sh ${WSO2_SERVER_HOME}/bin/dashboard.sh "$@"

--- a/dockerfiles/alpine/is-analytics/worker/Dockerfile
+++ b/dockerfiles/alpine/is-analytics/worker/Dockerfile
@@ -26,4 +26,4 @@ COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 EXPOSE 9090 9091 9443 7712 7612 9612 9712
 
 # start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/alpine/is-analytics/worker/init.sh
+++ b/dockerfiles/alpine/is-analytics/worker/init.sh
@@ -69,4 +69,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/worker.sh
+sh ${WSO2_SERVER_HOME}/bin/worker.sh "$@"

--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set to latest Alpine
-FROM adoptopenjdk/openjdk8:alpine
+FROM adoptopenjdk/openjdk8:jdk8u192-b12-alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations

--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set to latest Alpine
-FROM openjdk:8u171-jdk-alpine3.8
+FROM adoptopenjdk/openjdk8:alpine
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org”
 
 # set user configurations
@@ -61,7 +61,7 @@ RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
     chmod -R 755 ${USER_HOME}/.java && \
     chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
-# copy wso2 product distribution zip files to user's home directory and set ownership
+# copy wso2 product distribution zip file to user's home directory and set ownership
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy shared artifacts to a temporary location
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/repository/deployment/ ${USER_HOME}/wso2-tmp/deployment/
@@ -86,4 +86,4 @@ WORKDIR ${USER_HOME}
 EXPOSE 4000 9763 9443
 
 # initiate container and start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/alpine/is/README.md
+++ b/dockerfiles/alpine/is/README.md
@@ -17,12 +17,12 @@ git clone https://github.com/wso2/docker-is.git
 
 - Download [WSO2 Identity Server v5.7.0](https://wso2.com/identity-and-access-management/install/) 
 distribution and extract it to `<IS_DOCKERFILE_HOME>/files`. 
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) 
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j) 
 and copy that to `<IS_DOCKERFILE_HOME>/files`. <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <IS_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
+  <IS_DOCKERFILE_HOME>/files/mysql-connector-java-<version>-bin.jar
   <IS_DOCKERFILE_HOME>/files/wso2is-5.7.0
   ```
 >Please refer to [WSO2 Update Manager documentation]( https://docs.wso2.com/display/WUM300/WSO2+Update+Manager)

--- a/dockerfiles/alpine/is/init.sh
+++ b/dockerfiles/alpine/is/init.sh
@@ -24,6 +24,39 @@ deployment_volume=${WSO2_SERVER_HOME}/repository/deployment
 # original deployment artifacts
 original_deployment_artifacts=${WORKING_DIRECTORY}/wso2-tmp/deployment
 
+# a grace period for mounts to be setup
+echo "Waiting for all volumes to be mounted..."
+sleep 5
+
+verification_count=0
+verifyMountBeforeStart()
+{
+  if [ ${verification_count} -eq 5 ]
+  then
+    echo "Mount verification timed out"
+    return
+  fi
+
+  # increment the number of times the verification had occurred
+  verification_count=$((verification_count+1))
+
+  if [ ! -e $1 ]
+  then
+    echo "Directory $1 does not exist"
+    echo "Waiting for the volume to be mounted..."
+    sleep 5
+
+    echo "Retrying..."
+    verifyMountBeforeStart $1
+  else
+    echo "Directory $1 exists"
+  fi
+}
+
+verifyMountBeforeStart ${config_volume}
+verification_count=0
+verifyMountBeforeStart ${artifact_volume}
+
 # capture Docker container IP from the container's /etc/hosts file
 docker_container_ip=$(awk 'END{print $1}' /etc/hosts)
 
@@ -54,4 +87,4 @@ test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/repository/conf/axis2/axis2.xml
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/centos/is-analytics/README.md
+++ b/dockerfiles/centos/is-analytics/README.md
@@ -18,19 +18,18 @@ git clone https://github.com/wso2/docker-is.git
 
 >The local copy of the `dockerfile/centos/is-analytics` directory will be referred to as `ANALYTICS_DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Add JDK, WSO2 API Manager Analytics distributions and MySQL Connector to `<ANALYTICS_DOCKERFILE_HOME>/files`.
+##### 2. Add JDK, WSO2 Identity Server Analytics distributions and MySQL Connector to `<ANALYTICS_DOCKERFILE_HOME>/files`.
 
-- Download [JDK v1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) 
-and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
+- Download [AdoptOpenJDK 8](https://adoptopenjdk.net/) and extract it to `<ANALYTICS_DOCKERFILE_HOME>/files`.
 - Download the [WSO2 Identity Server Analytics 5.7.0](https://wso2.com/identity-and-access-management/install/analytics/)
 and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
 - Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) and copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/jdk<version>/
+  <ANALYTICS_DOCKERFILE_HOME>/base/files/jdk8u<version>/
   <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2am-analytics-5.7.0/
+  <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2is-analytics-5.7.0/
   ```
 
 >Please refer to [WSO2 Update Manager documentation](https://docs.wso2.com/display/WUM300/WSO2+Update+Manager)

--- a/dockerfiles/centos/is-analytics/README.md
+++ b/dockerfiles/centos/is-analytics/README.md
@@ -23,12 +23,12 @@ git clone https://github.com/wso2/docker-is.git
 - Download [AdoptOpenJDK 8](https://adoptopenjdk.net/) and extract it to `<ANALYTICS_DOCKERFILE_HOME>/files`.
 - Download the [WSO2 Identity Server Analytics 5.7.0](https://wso2.com/identity-and-access-management/install/analytics/)
 and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) and copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j) and copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
   <ANALYTICS_DOCKERFILE_HOME>/base/files/jdk8u<version>/
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
+  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-<version>-bin.jar
   <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2is-analytics-5.7.0/
   ```
 

--- a/dockerfiles/centos/is-analytics/base/Dockerfile
+++ b/dockerfiles/centos/is-analytics/base/Dockerfile
@@ -29,7 +29,7 @@ ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
 # set jdk configurations
-ARG JDK=jdk1.8.0*
+ARG JDK=jdk8u*
 ARG JAVA_HOME=${USER_HOME}/java
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2is-analytics

--- a/dockerfiles/centos/is-analytics/dashboard/Dockerfile
+++ b/dockerfiles/centos/is-analytics/dashboard/Dockerfile
@@ -26,4 +26,4 @@ COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 EXPOSE 9643
 
 # start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/centos/is-analytics/dashboard/init.sh
+++ b/dockerfiles/centos/is-analytics/dashboard/init.sh
@@ -69,4 +69,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/dashboard.sh
+sh ${WSO2_SERVER_HOME}/bin/dashboard.sh "$@"

--- a/dockerfiles/centos/is-analytics/worker/Dockerfile
+++ b/dockerfiles/centos/is-analytics/worker/Dockerfile
@@ -26,4 +26,4 @@ COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 EXPOSE 9090 9091 9443 7712 7612 9612 9712
 
 # start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/centos/is-analytics/worker/init.sh
+++ b/dockerfiles/centos/is-analytics/worker/init.sh
@@ -69,4 +69,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/worker.sh
+sh ${WSO2_SERVER_HOME}/bin/worker.sh "$@"

--- a/dockerfiles/centos/is/Dockerfile
+++ b/dockerfiles/centos/is/Dockerfile
@@ -29,7 +29,7 @@ ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
 # set jdk configurations
-ARG JDK=jdk1.8.0*
+ARG JDK=jdk8u*
 ARG JAVA_HOME=${USER_HOME}/java
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2is
@@ -73,7 +73,7 @@ WORKDIR ${USER_HOME}
 
 # set environment variables
 ENV JAVA_HOME=${JAVA_HOME} \
-    PATH=$JAVA_HOME/bin:$PATH \
+    PATH=${JAVA_HOME}/bin:$PATH \
     WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
     WORKING_DIRECTORY=${USER_HOME}
 
@@ -81,4 +81,4 @@ ENV JAVA_HOME=${JAVA_HOME} \
 EXPOSE 4000 9763 9443
 
 # initiate container and start WSO2 Carbon Server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/centos/is/README.md
+++ b/dockerfiles/centos/is/README.md
@@ -15,8 +15,7 @@ git clone https://github.com/wso2/docker-is.git
 
 ##### 2. Add JDK, WSO2 Identity Server distribution and MySQL connector to `<IS_DOCKERFILE_HOME>/files`.
 
-- Download [JDK v1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-and extract it to `<IS_DOCKERFILE_HOME>/files`.
+- Download [AdoptOpenJDK 8](https://adoptopenjdk.net/) and extract it to `<IS_DOCKERFILE_HOME>/files`.
 - Download [WSO2 Identity Server v5.7.0](https://wso2.com/identity-and-access-management/install/) 
 distribution and extract it to `<IS_DOCKERFILE_HOME>/files`. 
 - Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) 
@@ -24,7 +23,7 @@ and copy that to `<IS_DOCKERFILE_HOME>/files`. <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <IS_DOCKERFILE_HOME>/files/jdk<version>
+  <IS_DOCKERFILE_HOME>/files/jdk8u<version>/
   <IS_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
   <IS_DOCKERFILE_HOME>/files/wso2is-5.7.0
   ```

--- a/dockerfiles/centos/is/README.md
+++ b/dockerfiles/centos/is/README.md
@@ -13,7 +13,7 @@ git clone https://github.com/wso2/docker-is.git
 
 >The local copy of the `dockerfiles/centos/is` directory will be referred to as `IS_DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Add JDK, WSO2 Identity Server distribution and MySQL connector to `<IS_DOCKERFILE_HOME>/files`.
+##### 2. Add JDK, WSO2 Identity Server distributions and MySQL connector to `<IS_DOCKERFILE_HOME>/files`.
 
 - Download [AdoptOpenJDK 8](https://adoptopenjdk.net/) and extract it to `<IS_DOCKERFILE_HOME>/files`.
 - Download [WSO2 Identity Server v5.7.0](https://wso2.com/identity-and-access-management/install/) 

--- a/dockerfiles/centos/is/README.md
+++ b/dockerfiles/centos/is/README.md
@@ -18,13 +18,13 @@ git clone https://github.com/wso2/docker-is.git
 - Download [AdoptOpenJDK 8](https://adoptopenjdk.net/) and extract it to `<IS_DOCKERFILE_HOME>/files`.
 - Download [WSO2 Identity Server v5.7.0](https://wso2.com/identity-and-access-management/install/) 
 distribution and extract it to `<IS_DOCKERFILE_HOME>/files`. 
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) 
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j) 
 and copy that to `<IS_DOCKERFILE_HOME>/files`. <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
   <IS_DOCKERFILE_HOME>/files/jdk8u<version>/
-  <IS_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
+  <IS_DOCKERFILE_HOME>/files/mysql-connector-java-<version>-bin.jar
   <IS_DOCKERFILE_HOME>/files/wso2is-5.7.0
   ```
 >Please refer to [WSO2 Update Manager documentation]( https://docs.wso2.com/display/WUM300/WSO2+Update+Manager)

--- a/dockerfiles/centos/is/init.sh
+++ b/dockerfiles/centos/is/init.sh
@@ -87,4 +87,4 @@ test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/repository/conf/axis2/axis2.xml
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/ubuntu/is-analytics/README.md
+++ b/dockerfiles/ubuntu/is-analytics/README.md
@@ -18,19 +18,16 @@ git clone https://github.com/wso2/docker-is.git
 
 >The local copy of the `dockerfile/ubuntu/is-analytics` directory will be referred to as `ANALYTICS_DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Add JDK, WSO2 API Manager Analytics distributions and MySQL Connector to `<ANALYTICS_DOCKERFILE_HOME>/files`.
+##### 2. Add WSO2 Identity Server Analytics distribution and MySQL Connector to `<ANALYTICS_DOCKERFILE_HOME>/files`.
 
-- Download [JDK v1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) 
-and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
 - Download the [WSO2 Identity Server Analytics 5.7.0](https://wso2.com/identity-and-access-management/install/analytics/)
 and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
 - Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) and copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/jdk<version>/
   <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2am-analytics-5.7.0/
+  <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2is-analytics-5.7.0/
   ```
 
 >Please refer to [WSO2 Update Manager documentation](https://docs.wso2.com/display/WUM300/WSO2+Update+Manager)

--- a/dockerfiles/ubuntu/is-analytics/README.md
+++ b/dockerfiles/ubuntu/is-analytics/README.md
@@ -22,11 +22,11 @@ git clone https://github.com/wso2/docker-is.git
 
 - Download the [WSO2 Identity Server Analytics 5.7.0](https://wso2.com/identity-and-access-management/install/analytics/)
 and extract it to `<ANALYTICS_DOCKERFILE_HOME>/base/files`.
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) and copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j) and copy that to `<ANALYTICS_DOCKERFILE_HOME>/base/files` folder <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-5.1.45-bin.jar
+  <ANALYTICS_DOCKERFILE_HOME>/base/files/mysql-connector-java-<version>-bin.jar
   <ANALYTICS_DOCKERFILE_HOME>/base/files/wso2is-analytics-5.7.0/
   ```
 

--- a/dockerfiles/ubuntu/is-analytics/base/Dockerfile
+++ b/dockerfiles/ubuntu/is-analytics/base/Dockerfile
@@ -16,8 +16,8 @@
 #
 # ------------------------------------------------------------------------
 
-# set to latest Ubuntu LTS
-FROM ubuntu:18.04
+# set base Docker image to AdoptOpenJDK Ubuntu Docker image
+FROM adoptopenjdk/openjdk8:jdk8u192-b12
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations
@@ -28,9 +28,6 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
-# set jdk configurations
-ARG JDK=jdk1.8.0*
-ARG JAVA_HOME=${USER_HOME}/java
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2is-analytics
 ARG WSO2_SERVER_VERSION=5.7.0
@@ -51,14 +48,20 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
     >> /etc/bash.bashrc \
-    ; echo "$MOTD"  > /etc/motd
+    ; echo "$MOTD" > /etc/motd
 
 # create a user group and a user
 RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
     useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
 
-# copy the jdk and wso2 product distributions to user's home directory
-COPY --chown=wso2carbon:wso2 ${FILES}/${JDK} ${USER_HOME}/java/
+# create java prefs dir
+# this is to avoid warning logs printed by FileSystemPreferences class
+RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
+    mkdir -p ${USER_HOME}/.java/.userPrefs  && \
+    chmod -R 755 ${USER_HOME}/.java && \
+    chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
+
+# copy the wso2 product distribution to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy mysql connector jar to the server as a third party library
 COPY --chown=wso2carbon:wso2 ${FILES}/mysql-connector-java-*-bin.jar ${WSO2_SERVER_HOME}/lib/
@@ -68,7 +71,6 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_HOME=${JAVA_HOME} \
-    PATH=$JAVA_HOME/bin:$PATH \
-    WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
-    WORKING_DIRECTORY=${USER_HOME}
+ENV WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
+    WORKING_DIRECTORY=${USER_HOME} \
+    JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs"

--- a/dockerfiles/ubuntu/is-analytics/base/Dockerfile
+++ b/dockerfiles/ubuntu/is-analytics/base/Dockerfile
@@ -42,9 +42,7 @@ The Docker container contains the WSO2 product with its latest updates, which ar
 Read more about EULA 2.0 (https://wso2.com/licenses/wso2-update/2.0).\n"
 # install required packages
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    curl \
-    netcat && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends netcat && \
     rm -rf /var/lib/apt/lists/* && \
     echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
     >> /etc/bash.bashrc \
@@ -53,13 +51,6 @@ RUN apt-get update && \
 # create a user group and a user
 RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
     useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
-
-# create java prefs dir
-# this is to avoid warning logs printed by FileSystemPreferences class
-RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
-    mkdir -p ${USER_HOME}/.java/.userPrefs  && \
-    chmod -R 755 ${USER_HOME}/.java && \
-    chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
 
 # copy the wso2 product distribution to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
@@ -72,5 +63,4 @@ WORKDIR ${USER_HOME}
 
 # set environment variables
 ENV WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
-    WORKING_DIRECTORY=${USER_HOME} \
-    JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs"
+    WORKING_DIRECTORY=${USER_HOME}

--- a/dockerfiles/ubuntu/is-analytics/dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/is-analytics/dashboard/Dockerfile
@@ -26,4 +26,4 @@ COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 EXPOSE 9643
 
 # start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/ubuntu/is-analytics/dashboard/init.sh
+++ b/dockerfiles/ubuntu/is-analytics/dashboard/init.sh
@@ -36,4 +36,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/dashboard.sh
+sh ${WSO2_SERVER_HOME}/bin/dashboard.sh "$@"

--- a/dockerfiles/ubuntu/is-analytics/worker/Dockerfile
+++ b/dockerfiles/ubuntu/is-analytics/worker/Dockerfile
@@ -26,4 +26,4 @@ COPY --chown=wso2carbon:wso2 init.sh ${WORKING_DIRECTORY}/
 EXPOSE 9090 9091 9443 7712 7612 9612 9712
 
 # start WSO2 Carbon server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/ubuntu/is-analytics/worker/init.sh
+++ b/dockerfiles/ubuntu/is-analytics/worker/init.sh
@@ -36,4 +36,4 @@ test -d ${config_volume}/ && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
 test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/worker.sh
+sh ${WSO2_SERVER_HOME}/bin/worker.sh "$@"

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -16,8 +16,8 @@
 #
 # ------------------------------------------------------------------------
 
-# set to latest Ubuntu LTS
-FROM ubuntu:18.04
+# set base Docker image to AdoptOpenJDK Ubuntu Docker image
+FROM adoptopenjdk/openjdk8:jdk8u192-b12
 MAINTAINER WSO2 Docker Maintainers "dev@wso2.org"
 
 # set user configurations
@@ -28,9 +28,6 @@ ARG USER_GROUP_ID=802
 ARG USER_HOME=/home/${USER}
 # set dependant files directory
 ARG FILES=./files
-# set jdk configurations
-ARG JDK=jdk1.8.0*
-ARG JAVA_HOME=${USER_HOME}/java
 # set wso2 product configurations
 ARG WSO2_SERVER=wso2is
 ARG WSO2_SERVER_VERSION=5.7.0
@@ -52,14 +49,20 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
     >> /etc/bash.bashrc \
-    ; echo "$MOTD"  > /etc/motd
+    ; echo "$MOTD" > /etc/motd
 
 # create a user group and a user
 RUN groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} && \
     useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER}
 
-# copy the jdk and wso2 product distributions to user's home directory
-COPY --chown=wso2carbon:wso2 ${FILES}/${JDK} ${USER_HOME}/java/
+# create java prefs dir
+# this is to avoid warning logs printed by FileSystemPreferences class
+RUN mkdir -p ${USER_HOME}/.java/.systemPrefs && \
+    mkdir -p ${USER_HOME}/.java/.userPrefs  && \
+    chmod -R 755 ${USER_HOME}/.java && \
+    chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
+
+# copy the wso2 product distribution to user's home directory
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/ ${WSO2_SERVER_HOME}/
 # copy shared artifacts to a temporary location
 COPY --chown=wso2carbon:wso2 ${FILES}/${WSO2_SERVER_PACK}/repository/deployment/ ${USER_HOME}/wso2-tmp/deployment/
@@ -76,13 +79,12 @@ USER ${USER_ID}
 WORKDIR ${USER_HOME}
 
 # set environment variables
-ENV JAVA_HOME=${JAVA_HOME} \
-    PATH=$JAVA_HOME/bin:$PATH \
-    WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
-    WORKING_DIRECTORY=${USER_HOME}
+ENV WSO2_SERVER_HOME=${WSO2_SERVER_HOME} \
+    WORKING_DIRECTORY=${USER_HOME} \
+    JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs"
 
 # expose ports
 EXPOSE 4000 9763 9443
 
 # initiate container and start WSO2 Carbon Server
-ENTRYPOINT ${WORKING_DIRECTORY}/init.sh
+ENTRYPOINT ["/home/wso2carbon/init.sh"]

--- a/dockerfiles/ubuntu/is/README.md
+++ b/dockerfiles/ubuntu/is/README.md
@@ -13,10 +13,8 @@ git clone https://github.com/wso2/docker-is.git
 
 >The local copy of the `dockerfiles/ubuntu/is` directory will be referred to as `IS_DOCKERFILE_HOME` from this point onwards.
 
-##### 2. Add JDK, WSO2 Identity Server distribution and MySQL connector to `<IS_DOCKERFILE_HOME>/files`.
+##### 2. Add WSO2 Identity Server distribution and MySQL connector to `<IS_DOCKERFILE_HOME>/files`.
 
-- Download [JDK v1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-and extract it to `<IS_DOCKERFILE_HOME>/files`.
 - Download [WSO2 Identity Server v5.7.0](https://wso2.com/identity-and-access-management/install/) 
 distribution and extract it to `<IS_DOCKERFILE_HOME>/files`. 
 - Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) 
@@ -24,7 +22,6 @@ and copy that to `<IS_DOCKERFILE_HOME>/files`. <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <IS_DOCKERFILE_HOME>/files/jdk<version>
   <IS_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
   <IS_DOCKERFILE_HOME>/files/wso2is-5.7.0
   ```

--- a/dockerfiles/ubuntu/is/README.md
+++ b/dockerfiles/ubuntu/is/README.md
@@ -17,12 +17,12 @@ git clone https://github.com/wso2/docker-is.git
 
 - Download [WSO2 Identity Server v5.7.0](https://wso2.com/identity-and-access-management/install/) 
 distribution and extract it to `<IS_DOCKERFILE_HOME>/files`. 
-- Download [MySQL Connector JAR v5.1.45](https://downloads.mysql.com/archives/c-j) 
+- Download [MySQL Connector/J](https://downloads.mysql.com/archives/c-j) 
 and copy that to `<IS_DOCKERFILE_HOME>/files`. <br>
 - Once all of these are in place, it should look as follows:
 
   ```bash
-  <IS_DOCKERFILE_HOME>/files/mysql-connector-java-5.1.45-bin.jar
+  <IS_DOCKERFILE_HOME>/files/mysql-connector-java-<version>-bin.jar
   <IS_DOCKERFILE_HOME>/files/wso2is-5.7.0
   ```
 >Please refer to [WSO2 Update Manager documentation]( https://docs.wso2.com/display/WUM300/WSO2+Update+Manager)

--- a/dockerfiles/ubuntu/is/init.sh
+++ b/dockerfiles/ubuntu/is/init.sh
@@ -55,4 +55,4 @@ test -d ${artifact_volume}/ && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/repository/conf/axis2/axis2.xml
 
 # start WSO2 Carbon server
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"


### PR DESCRIPTION
## Purpose
> It is suggested to use AdoptOpenJDK 8 based Docker images for WSO2 Identity Server and related products. This PR fixes https://github.com/wso2/docker-is/issues/117, fixes https://github.com/wso2/docker-is/issues/118, fixes https://github.com/wso2/docker-is/issues/120 and fixes https://github.com/wso2/docker-is/issues/122.

## Goals
> Use AdoptOpenJDK in Alpine, CentOS and Ubuntu based Docker images.