### PR TITLE
Integrate differences between WSO2 Identity Server v5.8.0 RC-1 and RC-3

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -30,10 +30,6 @@ files:
         - operation: replace
           current_value: "{$arg.existing_version_wso2is}"
           new_value: "{$arg.new_version_wso2is}"
-    - file_path: docker-compose/is-with-analytics/docker-compose.yml
-      relative_path: ~
-      file_type: txt
-      configurations:
         - operation: replace
           current_value: "{$arg.existing_version_wso2is-analytics}"
           new_value: "{$arg.new_version_wso2is-analytics}"

--- a/docker-compose/is-with-analytics/identity-server/repository/conf/carbon.xml
+++ b/docker-compose/is-with-analytics/identity-server/repository/conf/carbon.xml
@@ -336,10 +336,6 @@
     <KeyResolvers>
       <KeyResolver className="org.wso2.carbon.crypto.defaultProvider.resolver.ContextIndependentKeyResolver" priority="-1"/>
     </KeyResolvers>
-    <!--
-            Uncomment the following configuration to use hardware security module for cryptographic operations.
-            Provide configurations as detailed in each tag.
-        -->
   </CryptoService>
   <!-- 
       Enable following config to allow Emails as usernames. 	

--- a/docker-compose/is-with-analytics/identity-server/repository/conf/identity/identity.xml
+++ b/docker-compose/is-with-analytics/identity-server/repository/conf/identity/identity.xml
@@ -308,11 +308,11 @@
         - Use tenant domain in local subject identifier.
         - Use user store domain in local subject identifier.
 
-        Default value : true
+        Default value : false
 
-        Supported versions: IS 5.8.0 beta onwards
+        Supported versions: IS 5.4.0 beta onwards
         -->
-    <BuildSubjectIdentifierFromSPConfig>true</BuildSubjectIdentifierFromSPConfig>
+    <!--<BuildSubjectIdentifierFromSPConfig>false</BuildSubjectIdentifierFromSPConfig>-->
     <!-- This should be set to true when using multiple user stores and keys
             should saved into different tables according to the user store. By default
             all the application keys are saved in to the same table. UserName Assertion


### PR DESCRIPTION
## Purpose
> It was identified that configuration file changes exist between WSO2 Identity Server v5.8.0 RC-1 and RC-3. These need to be integrated for the WSO2 Identity Server with Analytics Docker Compose based deployment.

## Goals
> Integrate differences between WSO2 Identity Server v5.8.0 RC-1 and RC-3