### PR TITLE
Integrate support in Docker Compose resources for users with and without WSO2 subscriptions

### DIFF
--- a/docker-compose/is-with-analytics/docker-compose.yml
+++ b/docker-compose/is-with-analytics/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       timeout: 60s
       retries: 5
   identity-server-analytics-worker:
-    image: docker.wso2.com/wso2is-analytics-worker:5.8.0
+    image: wso2/wso2is-analytics-worker:5.8.0
     ports:
       - "9091:9091"
       - "9444:9444"
@@ -30,7 +30,7 @@ services:
     volumes:
       - ./identity-server-analytics-worker:/home/wso2carbon/wso2-config-volume
   identity-server-analytics-dashboard:
-    image: docker.wso2.com/wso2is-analytics-dashboard:5.8.0
+    image: wso2/wso2is-analytics-dashboard:5.8.0
     ports:
       - "9643:9643"
     healthcheck:
@@ -45,7 +45,7 @@ services:
     volumes:
       - ./identity-server-analytics-dashboard:/home/wso2carbon/wso2-config-volume
   identity-server:
-    image: docker.wso2.com/wso2is:5.8.0
+    image: wso2/wso2is:5.8.0
     ports:
       - "9763:9763"
       - "9443:9443"

--- a/docker-compose/is-with-analytics/scripts/README.md
+++ b/docker-compose/is-with-analytics/scripts/README.md
@@ -1,7 +1,5 @@
 # WSO2 Identity Server deployment with WSO2 Identity Server Analytics
 
-![WSO2 Identity Server with Analytics](deployment-diagram.png)
-
 ## Prerequisites
 
  * Install [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), [Docker](https://www.docker.com/get-docker) and [Docker Compose](https://docs.docker.com/compose/install/#install-compose)
@@ -34,9 +32,9 @@
     
    **Note**: By default, each product profile service is configured to use WSO2 product Docker images with GA releases.
 
-  4. Execute following Docker Compose command to start the deployment.
+  4. Execute the `deploy.sh` script to start the deployment.
      ```
-     docker-compose up
+     ./deploy.sh
      ```
      
   5. Access management console via a web browser.

--- a/docker-compose/is-with-analytics/scripts/deploy.sh
+++ b/docker-compose/is-with-analytics/scripts/deploy.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------
+# Copyright 2019 WSO2, Inc. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ------------------------------------------------------------------------
+
+set -e
+
+ECHO=`which echo`
+GREP=`which grep`
+DOCKER_CLIENT=`which docker`
+DOCKER_COMPOSE_CLIENT=`which docker-compose`
+SED=`which sed`
+TEST=`which test`
+
+# methods
+function echoBold () {
+    ${ECHO} -e $'\e[1m'"${1}"$'\e[0m'
+}
+
+read -p "Do you have a WSO2 Subscription? (Y/N)" -n 1 -r
+${ECHO}
+
+if [[ ${REPLY} =~ ^[Yy]$ ]]; then
+    read -p "Enter Your WSO2 Username: " WSO2_SUBSCRIPTION_USERNAME
+    ${ECHO}
+    read -s -p "Enter Your WSO2 Password: " WSO2_SUBSCRIPTION_PASSWORD
+    ${ECHO}
+
+    echoBold "Logging into WSO2 Private Docker Registry (docker.wso2.com)"
+    ${DOCKER_CLIENT} login --username ${WSO2_SUBSCRIPTION_USERNAME} --password ${WSO2_SUBSCRIPTION_PASSWORD} docker.wso2.com
+
+    if ! ${SED} -i.bak -e 's|wso2/|docker.wso2.com/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the Docker image available at WSO2 Private Docker Registry (docker.wso2.com)"
+        exit 1
+    fi
+elif [[ ${REPLY} =~ ^[Nn]$ || -z "${REPLY}" ]]; then
+    if ! ${SED} -i.bak -e 's|docker.wso2.com/|wso2/|' ../docker-compose.yml; then
+        echoBold "Could not configure to use the WSO2 Docker image available at DockerHub"
+        exit 1
+    fi
+else
+    echoBold "You have entered an invalid option."
+    exit 1
+fi
+
+# remove backed up files
+${TEST} -f ../*.bak && rm ../*.bak
+
+cd ..
+
+${DOCKER_COMPOSE_CLIENT} up -d
+
+echoBold "
+To access the Management Console of WSO2 Identity Server, use https://localhost:9443/carbon.
+To access the Portal of WSO2 Analytics Dashboard, use https://localhost:9643/portal.
+
+To list the created WSO2 product server containers, use \`docker ps\` Docker client command.
+For instructions to delete the created WSO2 product server setup, please see the Docker Compose FAQ (https://wso2.com/products/install/faq/#iDocker)."


### PR DESCRIPTION
## Purpose
> Integrate support in Docker Compose resources for usage of both types of users: users with and without WSO2 subscriptions. Currently, only users with WSO2 subscriptions can utilize Docker Compose resources. This fixes https://github.com/wso2/docker-is/issues/136.

## Goals
> Integrate support in Docker Compose resources for users with and without WSO2 subscriptions