### PR TITLE
persist WSO2_CARBON_DB in mysql

### DIFF
--- a/docker-compose/is-with-analytics/identity-server/repository/conf/datasources/master-datasources.xml
+++ b/docker-compose/is-with-analytics/identity-server/repository/conf/datasources/master-datasources.xml
@@ -12,10 +12,10 @@
       </jndiConfig>
       <definition type="RDBMS">
         <configuration>
-          <url>jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>
-          <username>wso2carbon</username>
-          <password>wso2carbon</password>
-          <driverClassName>org.h2.Driver</driverClassName>
+          <url>jdbc:mysql://mysql:3306/wso2is_db?autoReconnect=true&amp;useSSL=false</url>
+          <username>root</username>
+          <password>root</password>
+          <driverClassName>com.mysql.jdbc.Driver</driverClassName>
           <maxActive>50</maxActive>
           <maxWait>60000</maxWait>
           <testOnBorrow>true</testOnBorrow>


### PR DESCRIPTION
persist WSO2_CARBON_DB in MySQL, because the H2 database file was in unmounted volume, so data would be removed after container recreation.