### PR TITLE
Upgrade MySQL JDBC Connector version from 5.1.47 to 8.0.17

### DIFF
--- a/dockerfiles/alpine/is-analytics/dashboard/Dockerfile
+++ b/dockerfiles/alpine/is-analytics/dashboard/Dockerfile
@@ -34,7 +34,7 @@ ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
  Welcome to WSO2 Docker Resources \n\

--- a/dockerfiles/alpine/is-analytics/worker/Dockerfile
+++ b/dockerfiles/alpine/is-analytics/worker/Dockerfile
@@ -34,7 +34,7 @@ ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
  Welcome to WSO2 Docker Resources \n\

--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -36,7 +36,7 @@ ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_pa
 # build arguments for external artifacts
 ARG DNS_JAVA_VERSION=2.1.8
 ARG K8S_MEMBERSHIP_SCHEME_VERSION=1.0.5
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
  Welcome to WSO2 Docker Resources \n\

--- a/dockerfiles/centos/is-analytics/dashboard/Dockerfile
+++ b/dockerfiles/centos/is-analytics/dashboard/Dockerfile
@@ -36,7 +36,7 @@ ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
 Welcome to WSO2 Docker resources.\n\

--- a/dockerfiles/centos/is-analytics/worker/Dockerfile
+++ b/dockerfiles/centos/is-analytics/worker/Dockerfile
@@ -36,7 +36,7 @@ ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
 Welcome to WSO2 Docker resources.\n\

--- a/dockerfiles/centos/is/Dockerfile
+++ b/dockerfiles/centos/is/Dockerfile
@@ -38,7 +38,7 @@ ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_pa
 # build arguments for external artifacts
 ARG DNS_JAVA_VERSION=2.1.8
 ARG K8S_MEMBERSHIP_SCHEME_VERSION=1.0.5
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD='printf "\n\
 Welcome to WSO2 Docker resources.\n\

--- a/dockerfiles/ubuntu/is-analytics/dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/is-analytics/dashboard/Dockerfile
@@ -34,7 +34,7 @@ ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\

--- a/dockerfiles/ubuntu/is-analytics/worker/Dockerfile
+++ b/dockerfiles/ubuntu/is-analytics/worker/Dockerfile
@@ -34,7 +34,7 @@ ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
 ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
 ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_path=${WSO2_SERVER}.zip
 # build arguments for external artifacts
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -36,7 +36,7 @@ ARG WSO2_SERVER_DIST_URL=https://bintray.com/wso2/binaryGA/download_file?file_pa
 # build arguments for external artifacts
 ARG DNS_JAVA_VERSION=2.1.8
 ARG K8S_MEMBERSHIP_SCHEME_VERSION=1.0.5
-ARG MYSQL_CONNECTOR_VERSION=5.1.47
+ARG MYSQL_CONNECTOR_VERSION=8.0.17
 # build argument for MOTD
 ARG MOTD="\n\
 Welcome to WSO2 Docker resources.\n\


### PR DESCRIPTION
## Purpose
> This PR upgrades the MySQL JDBC connector to latest version. This fixes https://github.com/wso2/docker-is/issues/119.

## Goals
> Upgrade MySQL JDBC connector to latest version