### PR TITLE
Updated to OpenJDK 11.0.7, Closes #201

### DIFF
--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk11:jdk-11.0.6_10-alpine
+FROM adoptopenjdk/openjdk11:jdk-11.0.7_10-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 
 # set Docker image build arguments

--- a/dockerfiles/centos/is/Dockerfile
+++ b/dockerfiles/centos/is/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
-FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.6_10
+FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.7_10
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 
 # set Docker image build arguments

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.6_10-jdk-hotspot-bionic
+FROM adoptopenjdk:11.0.7_10-jdk-hotspot-bionic
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 
 # set Docker image build arguments


### PR DESCRIPTION
- Updated to OpenJDK 11.0.7_10

## Purpose
Allow joining Kubernetes 1.16 clusters.

## Goals
Closing #201

## Approach
Updated to OpenJDK 11.0.7_10 which fixes [JDK-8236039](https://bugs.openjdk.java.net/browse/JDK-8236039) and allows joining Kubernetes 1.16 clusters.

## User stories
#201

## Release note
Upgraded to OpenJDK 11.0.7_10

## Automation tests
Not sure what automated tests are in place for Docker that may be affected

## Related PRs
wso2/kubernetes-is#221