### PR TITLE
[5.7.0] Add Git release tag as a label and enable SSL verification for wget

### DIFF
--- a/dockerfiles/alpine/is-analytics/dashboard/Dockerfile
+++ b/dockerfiles/alpine/is-analytics/dashboard/Dockerfile
@@ -57,7 +57,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 RUN apk add --no-cache netcat-openbsd
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip

--- a/dockerfiles/alpine/is-analytics/dashboard/Dockerfile
+++ b/dockerfiles/alpine/is-analytics/dashboard/Dockerfile
@@ -18,7 +18,8 @@
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
 FROM adoptopenjdk/openjdk8:jdk8u242-b08-alpine
-LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.7.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/alpine/is-analytics/worker/Dockerfile
+++ b/dockerfiles/alpine/is-analytics/worker/Dockerfile
@@ -57,7 +57,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 RUN apk add --no-cache netcat-openbsd
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip

--- a/dockerfiles/alpine/is-analytics/worker/Dockerfile
+++ b/dockerfiles/alpine/is-analytics/worker/Dockerfile
@@ -18,7 +18,8 @@
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
 FROM adoptopenjdk/openjdk8:jdk8u242-b08-alpine
-LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.7.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -67,7 +67,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 RUN apk add --no-cache netcat-openbsd
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip

--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -18,7 +18,8 @@
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
 FROM adoptopenjdk/openjdk8:jdk8u242-b08-alpine
-LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.7.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/centos/is-analytics/dashboard/Dockerfile
+++ b/dockerfiles/centos/is-analytics/dashboard/Dockerfile
@@ -64,7 +64,7 @@ RUN \
     && rm -rf /var/cache/yum/*
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip

--- a/dockerfiles/centos/is-analytics/dashboard/Dockerfile
+++ b/dockerfiles/centos/is-analytics/dashboard/Dockerfile
@@ -18,7 +18,8 @@
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
 FROM adoptopenjdk/openjdk8:jdk8u242-b08-centos
-LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.7.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/centos/is-analytics/worker/Dockerfile
+++ b/dockerfiles/centos/is-analytics/worker/Dockerfile
@@ -64,7 +64,7 @@ RUN \
     && rm -rf /var/cache/yum/*
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip

--- a/dockerfiles/centos/is-analytics/worker/Dockerfile
+++ b/dockerfiles/centos/is-analytics/worker/Dockerfile
@@ -18,7 +18,8 @@
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
 FROM adoptopenjdk/openjdk8:jdk8u242-b08-centos
-LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.7.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/centos/is/Dockerfile
+++ b/dockerfiles/centos/is/Dockerfile
@@ -64,7 +64,7 @@ RUN \
     && rm -rf /var/cache/yum/*
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip

--- a/dockerfiles/centos/is/Dockerfile
+++ b/dockerfiles/centos/is/Dockerfile
@@ -18,7 +18,8 @@
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
 FROM adoptopenjdk/openjdk8:jdk8u242-b08-centos
-LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"\
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.7.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/is-analytics/dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/is-analytics/dashboard/Dockerfile
@@ -62,7 +62,7 @@ RUN \
     && rm -rf /var/lib/apt/lists/*
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip

--- a/dockerfiles/ubuntu/is-analytics/dashboard/Dockerfile
+++ b/dockerfiles/ubuntu/is-analytics/dashboard/Dockerfile
@@ -18,7 +18,8 @@
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
 FROM adoptopenjdk:8u242-b08-jdk-hotspot-bionic
-LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.7.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/is-analytics/worker/Dockerfile
+++ b/dockerfiles/ubuntu/is-analytics/worker/Dockerfile
@@ -62,7 +62,7 @@ RUN \
     && rm -rf /var/lib/apt/lists/*
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip

--- a/dockerfiles/ubuntu/is-analytics/worker/Dockerfile
+++ b/dockerfiles/ubuntu/is-analytics/worker/Dockerfile
@@ -18,7 +18,8 @@
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
 FROM adoptopenjdk:8u242-b08-jdk-hotspot-bionic
-LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.7.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -72,7 +72,7 @@ RUN \
     && rm -rf /var/lib/apt/lists/*
 # add the WSO2 product distribution to user's home directory
 RUN \
-    wget --no-check-certificate -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -18,7 +18,8 @@
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
 FROM adoptopenjdk:8u242-b08-jdk-hotspot-bionic
-LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.7.0.4"
 
 # set Docker image build arguments
 # build arguments for user/group configurations


### PR DESCRIPTION
## Purpose
> This PR introduces the Docker source Git release tag as a label and enable SSL verification for wget. This fixes #230, #231  

## Goals
> Introduce the Docker source Git release tag as a label.
> Enable SSL verification for wget.

## Approach
> Use the dockerfile instruction LABEL to add Git release tag as a label.
> Removes existing option --no-check-certificate for wget.

## Test environment
> Client: Docker Engine - Community
 Version:           19.03.12
 API version:       1.40
 Go version:        go1.13.10
 Git commit:        48a66213fe
 Built:             Mon Jun 22 15:45:36 2020
 OS/Arch:           linux/amd64
 Experimental:      false

> Server: Docker Engine - Community
 Engine:
  Version:          19.03.12
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.13.10
  Git commit:       48a66213fe
  Built:            Mon Jun 22 15:44:07 2020
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.2.13
  GitCommit:        7ad184331fa3e55e52b890ea95e65ba581ae3429
 runc:
  Version:          1.0.0-rc10
  GitCommit:        dc9208a3303feef5b3839f4323d9beb36df0a9dd
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683