### PR TITLE
[5.10.0] Upgrade AdoptOpenJDK 11 version to the latest version - 11.0.9_11-jdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
-All notable changes to this project 5.10.x per each release will be documented in this file.
+All notable changes to Docker and Docker Compose resources for WSO2 Identity Server version `5.10.x` in each resource release,
+will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+## [v5.10.0.5] - 2020-11-27
+
+### Changed
+- Upgrade AdoptOpenJDK 11 version to the latest version - `11.0.9_11-jdk` (refer to [issue](https://github.com/wso2/docker-is/issues/261))
 
 ## [v5.10.0.4] - 2020-11-20
 
@@ -9,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add git release tag as a label (refer to [issue](https://github.com/wso2/docker-is/issues/220))
 
 ### Changed
-- Enable SSL verification when retrieving remote resources using wget (refer to [issue]https://github.com/wso2/docker-is/issues/219))
+- Enable SSL verification when retrieving remote resources using wget (refer to [issue](https://github.com/wso2/docker-is/issues/219))
 
 ## [v5.10.0.3] - 2020-07-23
 
@@ -38,6 +44,7 @@ For detailed information on the tasks carried out during this release, please se
 For detailed information on the tasks carried out during this release, please see the GitHub milestone
 [v5.10.0.1](https://github.com/wso2/docker-is/milestone/10).
 
+[v5.10.0.5]: https://github.com/wso2/docker-is/compare/v5.10.0.4...v5.10.0.5
 [v5.10.0.4]: https://github.com/wso2/docker-is/compare/v5.10.0.3...v5.10.0.4
 [v5.10.0.3]: https://github.com/wso2/docker-is/compare/v5.10.0.2...v5.10.0.3
 [v5.10.0.2]: https://github.com/wso2/docker-is/compare/v5.10.0.1...v5.10.0.2

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Docker Compose files have been created according to the most common IAM deployme
 to quickly evaluate product features along side their co-operate IAM requirements. The Compose files make use of per profile
 Docker images of WSO2 Identity Server and Analytics and MySQL.
 
-**Change log** from previous version 5.10.0.2 [View Here](CHANGELOG.md)
+**Change log** from previous version `5.10.0.4` [View Here](CHANGELOG.md)

--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk11:x86_64-alpine-jdk-11.0.9_11
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11-alpine
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.10.0.5"
 

--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk11:jdk-11.0.8_10-alpine
+FROM adoptopenjdk/openjdk11:x86_64-alpine-jdk-11.0.9_11
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.10.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.10.0.5"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/centos/is/Dockerfile
+++ b/dockerfiles/centos/is/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
-FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.9_11
+FROM adoptopenjdk/openjdk11:jdk-11.0.9_11-centos
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.10.0.5"
 

--- a/dockerfiles/centos/is/Dockerfile
+++ b/dockerfiles/centos/is/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK CentOS Docker image
-FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.8_10
+FROM adoptopenjdk/openjdk11:x86_64-centos-jdk-11.0.9_11
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.10.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.10.0.5"
 
 # set Docker image build arguments
 # build arguments for user/group configurations

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -17,9 +17,9 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk:11.0.8_10-jdk-hotspot-bionic
+FROM adoptopenjdk:11.0.9_11-jdk-hotspot-focal
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.10.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.10.0.5"
 
 # set Docker image build arguments
 # build arguments for user/group configurations


### PR DESCRIPTION
## Purpose
> This PR performs $subject. This fixes https://github.com/wso2/docker-is/issues/261.

## Goals
> Upgrade AdoptOpenJDK 11 version to the latest version - 11.0.9_11-jdk (2020/11/27)

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## Test environment
> Docker Engine Community version `19.03.5` (both client and server)