### PR TITLE
[IS 6.1.0] Fix Readme Doc Issue

### DIFF
--- a/dockerfiles/alpine/is/README.md
+++ b/dockerfiles/alpine/is/README.md
@@ -1,6 +1,6 @@
 # Dockerfile for WSO2 Identity Server #
 
-This section defines the step-by-step instructions to build an [Alpine](https://hub.docker.com/_/alpine/) Linux based Docker image for WSO2 Identity Server `5.11.0`.
+This section defines the step-by-step instructions to build an [Alpine](https://hub.docker.com/_/alpine/) Linux based Docker image for WSO2 Identity Server `6.1.0`.
 
 ## Prerequisites
 
@@ -31,7 +31,7 @@ git clone https://github.com/wso2/docker-is.git
 
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9443:9443 wso2is:5.11.0-alpine`
+- `docker run -it -p 9443:9443 wso2is:6.1.0-alpine`
 
 >Here, only port 9443 (HTTPS servlet transport) has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.

--- a/dockerfiles/centos/is/README.md
+++ b/dockerfiles/centos/is/README.md
@@ -1,6 +1,6 @@
 # Dockerfile for WSO2 Identity Server #
 
-This section defines the step-by-step instructions to build an [CentOS](https://hub.docker.com/_/centos/) Linux based Docker image for WSO2 Identity Server `5.11.0`.
+This section defines the step-by-step instructions to build an [CentOS](https://hub.docker.com/_/centos/) Linux based Docker image for WSO2 Identity Server `6.1.0`.
 
 ## Prerequisites
 
@@ -27,7 +27,7 @@ git clone https://github.com/wso2/docker-is.git
 > Tip - If you require the container to run with a different UID and GID, pass the preferred values of the UID and GID
 > as values for build arguments `USER_ID` and `USER_GROUP_ID` when building the image, as shown below. Note
 > that setting lower values for the UID and GID is not recommended.
-+ `docker build -t wso2is:5.11.0-centos --build-arg USER_ID=<UID> --build-arg USER_GROUP_ID=<GID> .`
++ `docker build -t wso2is:6.1.0-centos --build-arg USER_ID=<UID> --build-arg USER_GROUP_ID=<GID> .`
 
 ##### 3. Running the Docker image.
 


### PR DESCRIPTION
### Purpose
- Some places in readme docs, mention IS version as `5.11` and with this PR, it s corrected by replacing it with `6.1`.

