### PR TITLE
Upgrade ubuntu base image version to 24.04

### DIFF
--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to Ubuntu 20.04 Docker image
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
       com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.1"
@@ -107,7 +107,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 RUN \
     apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        netcat \
+        netcat-openbsd \
         unzip \
         wget \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Purpose
- Upgrade the ubuntu base image version to 24.04 version
- use netcat-openbsd instead of netcat because netcat is removed from ubuntu 24.04 and alternatives are netcat-traditional and netcat-openbsd.
   - use netcat-openbsd because in  in ubuntu 20.04 also using the netcat-openbsd with another version when installing it using netcat.
   - netcat and the netcat-openbsd has the same arguments with the `nc` command. 