### PR TITLE
[5.10.x] Upgrade glibc version to 2.35-r1

### DIFF
--- a/dockerfiles/jdk8/alpine/is/Dockerfile
+++ b/dockerfiles/jdk8/alpine/is/Dockerfile
@@ -38,8 +38,8 @@ RUN apk --no-progress --purge --no-cache upgrade \
 && curl --version
 
 RUN curl -o /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-&& curl -LO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.32-r0/glibc-2.32-r0.apk \
-&& apk add glibc-2.32-r0.apk
+&& curl -LO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk \
+&& apk add glibc-2.35-r1.apk
 
 #Install JDK8
 RUN set -eux; \


### PR DESCRIPTION
## Purpose

Upgrade glibc version to 2.35-r1 to address https://github.com/sgerrand/alpine-pkg-glibc/issues/185.

## Related Issues

- https://github.com/sgerrand/alpine-pkg-glibc/issues/185
