### PR TITLE
Add docker files for WSO2 IS with Post-Quantum TLS support

### DIFF
--- a/dockerfiles/pqc/is/Dockerfile
+++ b/dockerfiles/pqc/is/Dockerfile
@@ -1,0 +1,153 @@
+# ------------------------------------------------------------------------
+#
+# Copyright 2025 WSO2, LLC. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+#
+# ------------------------------------------------------------------------
+
+# Set base Docker image to Ubuntu 24.04 Docker image.
+FROM ubuntu:24.04
+
+LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.1.0.1"
+
+# Install JDK Dependencies.
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales \
+    && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+    && locale-gen en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_VERSION jdk-21.0.6+7
+
+# Install Temurin OpenJDK 21.
+RUN set -eux; \
+    ARCH="$(dpkg --print-architecture)"; \
+    case "${ARCH}" in \
+        amd64|x86_64) \
+            ESUM='a2650fba422283fbed20d936ce5d2a52906a5414ec17b2f7676dddb87201dbae'; \
+            BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_x64_linux_hotspot_21.0.6_7.tar.gz'; \
+            ;; \
+        aarch64|arm64) \
+            ESUM='04fe1273f624187d927f1b466e8cdb630d70786db07bee7599bfa5153060afd3'; \
+            BINARY_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.6_7.tar.gz'; \
+            ;; \
+       *) \
+            echo "Unsupported arch: ${ARCH}"; \
+            exit 1; \
+            ;; \
+    esac; \
+    curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
+    echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+    mkdir -p /opt/java/openjdk; \
+    cd /opt/java/openjdk; \
+    tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+    rm -rf /tmp/openjdk.tar.gz;
+
+ENV JAVA_HOME=/opt/java/openjdk \
+    PATH="/opt/java/openjdk/bin:$PATH"
+
+# Set Docker image build arguments.
+# Build arguments for user/group configurations.
+ARG USER=wso2carbon
+ARG USER_ID=802
+ARG USER_GROUP=wso2
+ARG USER_GROUP_ID=802
+ARG USER_HOME=/home/${USER}
+# Build arguments for WSO2 product installation.
+ARG WSO2_SERVER_NAME=wso2is
+ARG WSO2_SERVER_VERSION=7.1.0
+ARG WSO2_SERVER_REPOSITORY=product-is
+ARG WSO2_SERVER=${WSO2_SERVER_NAME}-${WSO2_SERVER_VERSION}
+ARG WSO2_SERVER_HOME=${USER_HOME}/${WSO2_SERVER}
+# Hosted wso2is-7.0.0 distribution URL.
+ARG WSO2_SERVER_DIST_URL=https://github.com/wso2/${WSO2_SERVER_REPOSITORY}/releases/download/v${WSO2_SERVER_VERSION}/${WSO2_SERVER}.zip
+# Build arguments for external artifacts.
+ARG DNS_JAVA_VERSION=3.6.1
+# Build argument for MOTD.
+ARG MOTD="\n\
+Welcome to WSO2 Docker resources.\n\
+------------------------------------ \n\
+This Docker container comprises of a WSO2 product, running with its latest GA release \n\
+which is under the Apache License, Version 2.0. \n\
+Read more about Apache License, Version 2.0 here @ http://www.apache.org/licenses/LICENSE-2.0.\n"
+
+# Create the non-root user and group and set MOTD login message.
+RUN \
+    groupadd --system -g ${USER_GROUP_ID} ${USER_GROUP} \
+    && useradd --system --create-home --home-dir ${USER_HOME} --no-log-init -g ${USER_GROUP_ID} -u ${USER_ID} ${USER} \
+    && echo '[ ! -z "${TERM}" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc; echo "${MOTD}" > /etc/motd
+
+# Create Java prefs dir.
+# This is to avoid warning logs printed by FileSystemPreferences class.
+RUN \
+    mkdir -p ${USER_HOME}/.java/.systemPrefs \
+    && mkdir -p ${USER_HOME}/.java/.userPrefs \
+    && chmod -R 755 ${USER_HOME}/.java \
+    && chown -R ${USER}:${USER_GROUP} ${USER_HOME}/.java
+
+# Copy init script to user home.
+COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
+
+# Install required packages.
+RUN \
+    apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        netcat-openbsd \
+        unzip \
+        wget \
+        make \
+        cmake \
+        gcc \
+        libapr1-dev \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN \
+    wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
+    && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
+    && rm -f ${WSO2_SERVER}.zip
+
+# Install post quantum libraries.
+RUN \
+    cd ${WSO2_SERVER_HOME}/bin \
+    && sh openssl-tls.sh --build_pqclib
+
+# Add configurations to enable Post Quantum TLS.
+RUN echo "[transport.https.openssl]\n" \
+    "enabled = true\n" \
+    "named_groups=\"X25519MLKEM768:x25519\"\n\n" \
+    "[transport.https.sslHostConfig.properties]\n" \
+    "protocols=\"TLSv1+TLSv1.1+TLSv1.2+TLSv1.3\"" >> ${WSO2_SERVER_HOME}/repository/conf/deployment.toml
+    
+# Add libraries for Kubernetes membership scheme based clustering.
+ADD --chown=wso2carbon:wso2 https://repo1.maven.org/maven2/dnsjava/dnsjava/${DNS_JAVA_VERSION}/dnsjava-${DNS_JAVA_VERSION}.jar ${WSO2_SERVER_HOME}/repository/components/lib
+
+# Set the user and work directory.
+USER ${USER_ID}
+WORKDIR ${USER_HOME}
+
+# Set environment variables.
+ENV JAVA_OPTS="-Djava.util.prefs.systemRoot=${USER_HOME}/.java -Djava.util.prefs.userRoot=${USER_HOME}/.java/.userPrefs" \
+    WORKING_DIRECTORY=${USER_HOME} \
+    WSO2_SERVER_HOME=${WSO2_SERVER_HOME}
+
+# Expose ports.
+EXPOSE 4000 9763 9443
+
+# Initiate container and start WSO2 Carbon server.
+ENTRYPOINT ["/home/wso2carbon/docker-entrypoint.sh"]

--- a/dockerfiles/pqc/is/README.md
+++ b/dockerfiles/pqc/is/README.md
@@ -16,22 +16,22 @@ based Docker image for WSO2 Identity Server `7.1.0` with [Post-Quantum TLS suppo
 git clone https://github.com/wso2/docker-is.git
 ```
 
->The local copy of the `dockerfiles/ubuntu/is` directory will be referred to as `IS_DOCKERFILE_HOME` from this point onwards.
+>The local copy of the `dockerfiles/pqc/is` directory will be referred to as `IS_DOCKERFILE_HOME` from this point onwards.
 
 ##### 2.  Build the Docker image.
 
 - Navigate to `<IS_DOCKERFILE_HOME>` directory. <br>
   Execute `docker build` command as shown below.
-    + `docker build -t wso2is:7.1.0 .`
+    + `docker build -t wso2is:7.1.0-pqc .`
 
 > Tip - If you require the container to run with a different UID and GID, pass the preferred values of the UID and GID
 > as values for build arguments `USER_ID` and `USER_GROUP_ID` when building the image, as shown below. Note
 > that setting lower values for the UID and GID is not recommended.
-+ `docker build -t wso2is:7.1.0 --build-arg USER_ID=<UID> --build-arg USER_GROUP_ID=<GID> .`
++ `docker build -t wso2is:7.1.0-pqc --build-arg USER_ID=<UID> --build-arg USER_GROUP_ID=<GID> .`
 
 ##### 3. Running the Docker image.
 
-- `docker run -it -p 9443:9443 wso2is:7.1.0`
+- `docker run -it -p 9443:9443 wso2is:7.1.0-pqc`
 
 >Here, only port 9443 (HTTPS servlet transport) has been mapped to a Docker host port.
 You may map other container service ports, which have been exposed to Docker host ports, as desired.
@@ -67,7 +67,7 @@ chmod o+r <SOURCE_CONFIGS>/deployment.toml
 docker run \
 -p 9444:9444 \
 --volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
-wso2is:7.1.0
+wso2is:7.1.0-pqc
 ```
 
 >In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2is-7.1.0/repository/conf folder of the container.

--- a/dockerfiles/pqc/is/README.md
+++ b/dockerfiles/pqc/is/README.md
@@ -1,0 +1,79 @@
+# Dockerfile for WSO2 Identity Server with Post-Quantum TLS #
+
+This section defines the step-by-step instructions to build an [Ubuntu](https://hub.docker.com/_/ubuntu/) Linux
+based Docker image for WSO2 Identity Server `7.1.0` with [Post-Quantum TLS support](https://is.docs.wso2.com/en/7.1.0/deploy/security/configure-post-quantum-tls/).
+
+## Prerequisites
+
+* [Docker](https://www.docker.com/get-docker) `v17.09.0` or above
+* [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) client
+
+## How to build an image and run
+
+##### 1. Checkout this repository into your local machine using the following Git client command.
+
+```
+git clone https://github.com/wso2/docker-is.git
+```
+
+>The local copy of the `dockerfiles/ubuntu/is` directory will be referred to as `IS_DOCKERFILE_HOME` from this point onwards.
+
+##### 2.  Build the Docker image.
+
+- Navigate to `<IS_DOCKERFILE_HOME>` directory. <br>
+  Execute `docker build` command as shown below.
+    + `docker build -t wso2is:7.1.0 .`
+
+> Tip - If you require the container to run with a different UID and GID, pass the preferred values of the UID and GID
+> as values for build arguments `USER_ID` and `USER_GROUP_ID` when building the image, as shown below. Note
+> that setting lower values for the UID and GID is not recommended.
++ `docker build -t wso2is:7.1.0 --build-arg USER_ID=<UID> --build-arg USER_GROUP_ID=<GID> .`
+
+##### 3. Running the Docker image.
+
+- `docker run -it -p 9443:9443 wso2is:7.1.0`
+
+>Here, only port 9443 (HTTPS servlet transport) has been mapped to a Docker host port.
+You may map other container service ports, which have been exposed to Docker host ports, as desired.
+
+##### 4. Accessing management consoles.
+
+- To access the user interfaces, use the docker host IP and port 9443.
+    + Management Console: `https://<DOCKER_HOST>:9443/console`
+    + User Portal: `https://<DOCKER_HOST>:9443/myaccount`
+    
+>In here, <DOCKER_HOST> refers to hostname or IP of the host machine on top of which containers are spawned.
+
+## How to update configurations
+
+Configurations would lie on the Docker host machine and they can be volume mounted to the container. <br>
+As an example, steps required to change the port offset using `deployment.toml` is as follows:
+
+##### 1. Stop the Identity Server container if it's already running.
+
+In WSO2 Identity Server version `7.1.0` product distribution, `deployment.toml` configuration file <br>
+can be found at `<DISTRIBUTION_HOME>/repository/conf`. Copy the file to some suitable location of the host machine, <br>
+referred to as `<SOURCE_CONFIGS>/deployment.toml` and change the `[server] -> offset` value to 1.
+
+##### 2. Grant read permission to `other` users for `<SOURCE_CONFIGS>/deployment.toml`.
+
+```
+chmod o+r <SOURCE_CONFIGS>/deployment.toml
+```
+
+##### 3. Run the image by mounting the file to container as follows:
+
+```
+docker run \
+-p 9444:9444 \
+--volume <SOURCE_CONFIGS>/deployment.toml:<TARGET_CONFIGS>/deployment.toml \
+wso2is:7.1.0
+```
+
+>In here, <TARGET_CONFIGS> refers to /home/wso2carbon/wso2is-7.1.0/repository/conf folder of the container.
+
+## Docker command usage references
+
+* [Docker build command reference](https://docs.docker.com/engine/reference/commandline/build/)
+* [Docker run command reference](https://docs.docker.com/engine/reference/run/)
+* [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)

--- a/dockerfiles/pqc/is/docker-entrypoint.sh
+++ b/dockerfiles/pqc/is/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# ------------------------------------------------------------------------
+# Copyright 2021 WSO2, LLC. (http://wso2.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+# ------------------------------------------------------------------------
+
+set -e
+
+# Volume mounts.
+config_volume=${WORKING_DIRECTORY}/wso2-config-volume
+artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
+
+# Check if the WSO2 non-root user home exists.
+test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not exist" && exit 1
+
+# Check if the WSO2 product home exists.
+test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
+
+# Copy any configuration changes mounted to config_volume.
+test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+# Copy any artifact changes mounted to artifact_volume.
+test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+
+# Start WSO2 Carbon server.
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"


### PR DESCRIPTION
Create a separate docker file with Post Quantum TLS enabled by default
 - JDK 21
 - Ubuntu 24.04