### PR TITLE
[6.0] Update base Docker image to Ubuntu 24.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ in each resource release, will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v6.0.0.8 - 2025-11-07
+
+### Changed
+- Update base Docker image to Ubuntu 24.04
+
 ## v6.0.0.7 - 2024-12-18
 
 ### Changed

--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to Alpine Docker image
 FROM alpine:3.20.3
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.0.0.7"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.0.0.8"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' 
 

--- a/dockerfiles/centos/is/Dockerfile
+++ b/dockerfiles/centos/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to CentOS Docker image
 FROM centos:7
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.0.0.7"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.0.0.8"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/dockerfiles/rocky/is/Dockerfile
+++ b/dockerfiles/rocky/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to CentOS Docker image
 FROM rockylinux:8
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.0.0.7"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.0.0.8"
 
 # Update the system to the specific 8.10 version
 RUN dnf -y update && \

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -16,7 +16,7 @@
 #
 # ------------------------------------------------------------------------
 
-# set base Docker image to Ubuntu 20.04 Docker image
+# set base Docker image to Ubuntu 24.04 Docker image
 FROM ubuntu:24.04
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -17,10 +17,10 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to Ubuntu 20.04 Docker image
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.0.0.7"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.0.0.8"
 
 #Install JDK Dependencies
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -102,7 +102,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 RUN \
     apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        netcat \
+        netcat-openbsd \
         unzip \
         wget \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Purpose
This pull request updates the Docker images for all supported platforms to the latest release version (v6.0.0.8), with a notable upgrade of the Ubuntu base image from 20.04 to 24.04. Additionally, it replaces the `netcat` package with `netcat-openbsd` in the Ubuntu Dockerfile to improve compatibility with the new base image.

**Platform version updates:**

* Upgraded the base Docker image in `dockerfiles/ubuntu/is/Dockerfile` from `ubuntu:20.04` to `ubuntu:24.04` for improved security and support.
* Updated the release tag references in all Dockerfiles (`alpine`, `centos`, `rocky`, `ubuntu`) to v6.0.0.8 to reflect the new release. [[1]](diffhunk://#diff-a498d0f18ce4069c4d21d0e71212ae3ec4009222726af266b72cc8e99af22d63L22-R22) [[2]](diffhunk://#diff-5e3b36dc781c192d62e5c6d7567e9b19e95cf60dda6fa21680c78252aa81c762L22-R22) [[3]](diffhunk://#diff-9c9eec07926d01f199bd16046529cd701706e540453dfbd43fc619c211675599L22-R22) [[4]](diffhunk://#diff-27630637247b8a256d9327bf82e1112c169d25169b28c892536787238bc00bf0L20-R23)

**Package changes for compatibility:**

* Replaced the `netcat` package with `netcat-openbsd` in the Ubuntu Dockerfile to ensure compatibility with Ubuntu 24.04.

**Documentation:**

* Added a new changelog entry for v6.0.0.8 noting the update to Ubuntu 24.04 as the base image.