### PR TITLE
[7.0] Update base Docker image to Ubuntu 24.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ in each resource release, will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v7.0.0.5 - 2025-11-10
+
+### Changed
+- Update base Docker image to Ubuntu 24.04
+
 ## v7.0.0.4 - 2024-12-18
 
 ### Changed

--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to Alpine Docker image
 FROM alpine:3.20.3
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.5"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' 
 

--- a/dockerfiles/centos/is/Dockerfile
+++ b/dockerfiles/centos/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to CentOS Docker image
 FROM centos:7
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.5"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/dockerfiles/jdk17/alpine/is/Dockerfile
+++ b/dockerfiles/jdk17/alpine/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to Alpine Docker image
 FROM alpine:3.20.3
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.5"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' 
 

--- a/dockerfiles/jdk17/centos/is/Dockerfile
+++ b/dockerfiles/jdk17/centos/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to CentOS Docker image
 FROM centos:7
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.5"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/dockerfiles/jdk17/rocky/is/Dockerfile
+++ b/dockerfiles/jdk17/rocky/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to RockyLinux Docker image
 FROM rockylinux:8
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.5"
 
 # Update the system to the specific 8.10 version
 RUN dnf -y update && \

--- a/dockerfiles/jdk17/ubuntu/is/Dockerfile
+++ b/dockerfiles/jdk17/ubuntu/is/Dockerfile
@@ -16,7 +16,7 @@
 #
 # ------------------------------------------------------------------------
 
-# set base Docker image to Ubuntu 20.04 Docker image
+# set base Docker image to Ubuntu 24.04 Docker image
 FROM ubuntu:24.04
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \

--- a/dockerfiles/jdk17/ubuntu/is/Dockerfile
+++ b/dockerfiles/jdk17/ubuntu/is/Dockerfile
@@ -17,10 +17,10 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to Ubuntu 20.04 Docker image
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.5"
 
 #Install JDK Dependencies
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -106,7 +106,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 RUN \
     apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        netcat \
+        netcat-openbsd \
         unzip \
         wget \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/rocky/is/Dockerfile
+++ b/dockerfiles/rocky/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to RockyLinux Docker image
 FROM rockylinux:8
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.5"
 
 # Update the system to the specific 8.10 version
 RUN dnf -y update && \

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -16,7 +16,7 @@
 #
 # ------------------------------------------------------------------------
 
-# set base Docker image to Ubuntu 20.04 Docker image
+# set base Docker image to Ubuntu 24.04 Docker image
 FROM ubuntu:24.04
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -17,10 +17,10 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to Ubuntu 20.04 Docker image
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.4"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v7.0.0.5"
 
 #Install JDK Dependencies
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -106,7 +106,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 RUN \
     apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        netcat \
+        netcat-openbsd \
         unzip \
         wget \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Purpose
This pull request updates the Docker image configurations for the next release (`v7.0.0.5`) of the project, with the primary change being an upgrade of the base Ubuntu image from `20.04` to `24.04` across relevant Dockerfiles. It also updates the release references and replaces the `netcat` package with `netcat-openbsd` in Ubuntu-based images to ensure compatibility with the new Ubuntu version.

**Base image upgrades:**

* Updated the base image in `dockerfiles/ubuntu/is/Dockerfile` and `dockerfiles/jdk17/ubuntu/is/Dockerfile` from `ubuntu:20.04` to `ubuntu:24.04` for improved security and support. [[1]](diffhunk://#diff-27630637247b8a256d9327bf82e1112c169d25169b28c892536787238bc00bf0L20-R23) [[2]](diffhunk://#diff-ca37a84e4ba6a540feeb8ea07841a7f362563c3c550a3664e4d5515e47f60b8eL20-R23)
* Updated the changelog in `CHANGELOG.md` to document the switch to Ubuntu 24.04 for this release.

**Package and dependency changes:**

* Replaced the `netcat` package with `netcat-openbsd` in both `dockerfiles/ubuntu/is/Dockerfile` and `dockerfiles/jdk17/ubuntu/is/Dockerfile` to maintain compatibility with Ubuntu 24.04. [[1]](diffhunk://#diff-27630637247b8a256d9327bf82e1112c169d25169b28c892536787238bc00bf0L109-R109) [[2]](diffhunk://#diff-ca37a84e4ba6a540feeb8ea07841a7f362563c3c550a3664e4d5515e47f60b8eL109-R109)

**Release metadata updates:**

* Updated the release tag reference from `v7.0.0.4` to `v7.0.0.5` in all Dockerfiles to reflect the new version. [[1]](diffhunk://#diff-a498d0f18ce4069c4d21d0e71212ae3ec4009222726af266b72cc8e99af22d63L22-R22) [[2]](diffhunk://#diff-5e3b36dc781c192d62e5c6d7567e9b19e95cf60dda6fa21680c78252aa81c762L22-R22) [[3]](diffhunk://#diff-d7c8b092ea985893c60c51da32c629d81716e5c91938474f0476a1c5f6572baeL22-R22) [[4]](diffhunk://#diff-f93fdd436378edf1ea33763c609922aa6ef505b80442508bd747dd6b7cedd1b0L22-R22) [[5]](diffhunk://#diff-ebb3b19cf2e309de51c5c1b7f76179d00f7ba05b335006a356a68124fd074724L22-R22) [[6]](diffhunk://#diff-9c9eec07926d01f199bd16046529cd701706e540453dfbd43fc619c211675599L22-R22) [[7]](diffhunk://#diff-ca37a84e4ba6a540feeb8ea07841a7f362563c3c550a3664e4d5515e47f60b8eL20-R23) [[8]](diffhunk://#diff-27630637247b8a256d9327bf82e1112c169d25169b28c892536787238bc00bf0L20-R23)