### PR TITLE
[6.1] Update base Docker image to Ubuntu 24.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ in each resource release, will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v6.1.0.15 - 2025-11-10
+
+### Changed
+- Update base Docker image to Ubuntu 24.04
+
 ## v6.1.0.14 - 2025-07-03
 
 ### Changed

--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to Alpine Docker image
 FROM alpine:3.21.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.14"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.15"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' 
 

--- a/dockerfiles/centos/is/Dockerfile
+++ b/dockerfiles/centos/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to CentOS Docker image
 FROM centos:7
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.14"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.15"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/dockerfiles/jdk17/alpine/is/Dockerfile
+++ b/dockerfiles/jdk17/alpine/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to Alpine Docker image
 FROM alpine:3.21.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.14"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.15"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' 
 

--- a/dockerfiles/jdk17/centos/is/Dockerfile
+++ b/dockerfiles/jdk17/centos/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to CentOS Docker image
 FROM centos:7
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.14"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.15"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/dockerfiles/jdk17/rocky/is/Dockerfile
+++ b/dockerfiles/jdk17/rocky/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to Rocky Linux Docker image
 FROM rockylinux:8
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.14"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.15"
 
 # Update the system to the specific 8.10 version
 RUN dnf -y update && \

--- a/dockerfiles/jdk17/ubuntu/is/Dockerfile
+++ b/dockerfiles/jdk17/ubuntu/is/Dockerfile
@@ -16,7 +16,7 @@
 #
 # ------------------------------------------------------------------------
 
-# set base Docker image to Ubuntu 20.04 Docker image
+# set base Docker image to Ubuntu 24.04 Docker image
 FROM ubuntu:24.04
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \

--- a/dockerfiles/jdk17/ubuntu/is/Dockerfile
+++ b/dockerfiles/jdk17/ubuntu/is/Dockerfile
@@ -17,10 +17,10 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to Ubuntu 20.04 Docker image
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.14"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.15"
 
 #Install JDK Dependencies
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -107,7 +107,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 RUN \
     apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        netcat \
+        netcat-openbsd \
         unzip \
         wget \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/rocky/is/Dockerfile
+++ b/dockerfiles/rocky/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to Rocky Linux Docker image
 FROM rockylinux:8
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.14"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.15"
 
 # Update the system to the specific 8.10 version
 RUN dnf -y update && \

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -16,7 +16,7 @@
 #
 # ------------------------------------------------------------------------
 
-# set base Docker image to Ubuntu 20.04 Docker image
+# set base Docker image to Ubuntu 24.04 Docker image
 FROM ubuntu:24.04
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -17,10 +17,10 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to Ubuntu 20.04 Docker image
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.14"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v6.1.0.15"
 
 #Install JDK Dependencies
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -107,7 +107,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 RUN \
     apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        netcat \
+        netcat-openbsd \
         unzip \
         wget \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Purpose
This pull request updates the Docker resources for WSO2 Identity Server to support newer base images and JDK versions, introduces JDK 17-based images, and streamlines the build process by switching to hosted product distributions. The documentation has also been revised to reflect these changes and improve clarity.

**Dockerfile updates:**
- Upgraded base images to Alpine 3.21.0 and CentOS 7, and updated the product version references and maintainer tags in both `dockerfiles/alpine/is/Dockerfile` and `dockerfiles/centos/is/Dockerfile`. [[1]](diffhunk://#diff-a498d0f18ce4069c4d21d0e71212ae3ec4009222726af266b72cc8e99af22d63L20-R39) [[2]](diffhunk://#diff-5e3b36dc781c192d62e5c6d7567e9b19e95cf60dda6fa21680c78252aa81c762L22-R38)
- Updated JDK versions to `jdk-11.0.20.1+1` for both Alpine and CentOS images, and upgraded DNS Java library to `3.6.1`. [[1]](diffhunk://#diff-a498d0f18ce4069c4d21d0e71212ae3ec4009222726af266b72cc8e99af22d63L20-R39) [[2]](diffhunk://#diff-5e3b36dc781c192d62e5c6d7567e9b19e95cf60dda6fa21680c78252aa81c762L22-R38) [[3]](diffhunk://#diff-a498d0f18ce4069c4d21d0e71212ae3ec4009222726af266b72cc8e99af22d63R73-L76) [[4]](diffhunk://#diff-5e3b36dc781c192d62e5c6d7567e9b19e95cf60dda6fa21680c78252aa81c762R68-L71)
- Changed the product installation method from copying a local ZIP file to downloading the distribution from a configurable URL (`WSO2_SERVER_DIST_URL`), removing the need for local artifact management. [[1]](diffhunk://#diff-a498d0f18ce4069c4d21d0e71212ae3ec4009222726af266b72cc8e99af22d63L109-R122) [[2]](diffhunk://#diff-5e3b36dc781c192d62e5c6d7567e9b19e95cf60dda6fa21680c78252aa81c762L105-R118)
- Removed the default MySQL JDBC connector from the Docker build process. [[1]](diffhunk://#diff-a498d0f18ce4069c4d21d0e71212ae3ec4009222726af266b72cc8e99af22d63R73-L76) [[2]](diffhunk://#diff-5e3b36dc781c192d62e5c6d7567e9b19e95cf60dda6fa21680c78252aa81c762R68-L71) [[3]](diffhunk://#diff-a498d0f18ce4069c4d21d0e71212ae3ec4009222726af266b72cc8e99af22d63L109-R122) [[4]](diffhunk://#diff-5e3b36dc781c192d62e5c6d7567e9b19e95cf60dda6fa21680c78252aa81c762L105-R118)

**New JDK 17 Alpine Dockerfile:**
- Added `dockerfiles/jdk17/alpine/is/Dockerfile` to provide an Alpine-based JDK 17 image for WSO2 Identity Server 6.1.0, with updated installation steps and dependencies.

**Documentation improvements:**
- Updated `README.md` files for both Alpine and CentOS to reflect the new build process, product version, and usage of hosted distribution URLs. Simplified build and run instructions, and fixed outdated references. [[1]](diffhunk://#diff-9e17bb67fe7cf7c415d60a3736196e3bf2fc83b6d5c36541da6ab7ce4a5bf17dL3-R3) [[2]](diffhunk://#diff-9e17bb67fe7cf7c415d60a3736196e3bf2fc83b6d5c36541da6ab7ce4a5bf17dL20-R39) [[3]](diffhunk://#diff-3b73202b6c20d0fd468dadf174ca65aade3793ac6fe056ac293128283cee7735L3-R3) [[4]](diffhunk://#diff-3b73202b6c20d0fd468dadf174ca65aade3793ac6fe056ac293128283cee7735L20-R39) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R17)

**Changelog updates:**
- Added detailed changelog entries for all recent changes, including base image upgrades, JDK updates, and new JDK 17 support.