### PR TITLE
[5.11.0] Update JDK version to jdk8u452-b09

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ in each resource release, will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v5.11.0.28] - 2025-11-10
+
+### Changed
+- Update jdk8 version to jdk8u452-b09
+
 ## [v5.11.0.27] - 2025-07-04
 
 ### Changed

--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to Alpine Docker image
 FROM alpine:3.20.6
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.27"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.28"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/dockerfiles/centos/is/Dockerfile
+++ b/dockerfiles/centos/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to CentOS Docker image
 FROM centos:7
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.27"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.28"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 

--- a/dockerfiles/jdk8/alpine/is/Dockerfile
+++ b/dockerfiles/jdk8/alpine/is/Dockerfile
@@ -19,14 +19,14 @@
 # set base Docker image to Alpine Docker image
 FROM alpine:3.20.6
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.27"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.28"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Install JDK Dependencies
 RUN apk add --no-cache tzdata musl-locales musl-locales-lang \
     && rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION jdk8u362-b09
+ENV JAVA_VERSION jdk8u452-b09
 
 RUN apk --no-progress --purge --no-cache upgrade \
 && apk --no-progress --purge --no-cache add --upgrade \
@@ -47,8 +47,8 @@ RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
         amd64|x86_64) \
-            ESUM='389c0d2ea59742103f46f1dd6d2c83e43e9f935f3f0485b1f9e74ac4e8c5ce47'; \
-            BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u362-b09/OpenJDK8U-jdk_x64_alpine-linux_hotspot_8u362b09.tar.gz'; \
+            ESUM='be8abae7586c328ceb3252aefed9e51c29be91616968c0130b41e7e57c846f0f'; \
+            BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_x64_alpine-linux_hotspot_8u452b09.tar.gz'; \
             ;; \
         aarch64|arm64) \
             ESUM='69d39682c4a2fac294a9eaacbf62c26d3c8a2f9123f1b5d287498a5472c6b672'; \

--- a/dockerfiles/jdk8/centos/is/Dockerfile
+++ b/dockerfiles/jdk8/centos/is/Dockerfile
@@ -19,22 +19,22 @@
 # set base Docker image to CentOS Docker image
 FROM centos:7
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.27"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.28"
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Instal JDK Dependencies
 RUN yum install -y tzdata openssl curl ca-certificates fontconfig gzip tar \
     && yum clean all
 
-ENV JAVA_VERSION jdk8u362-b09
+ENV JAVA_VERSION jdk8u452-b09
 
 # Install JDK8
 RUN set -eux; \
     ARCH="$(objdump="$(command -v objdump)" && objdump --file-headers "$objdump" | awk -F '[:,]+[[:space:]]+' '$1 == "architecture" { print $2 }')"; \
         case "${ARCH}" in \
         amd64|i386:x86-64) \
-            ESUM='1486a792fb224611ce0cd0e83d4aacd3503b56698549f8e9a9f0a6ebb83bdba1'; \
-            BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u362-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u362b09.tar.gz'; \
+            ESUM='9448308a21841960a591b47927cf2d44fdc4c0533a5f8111a4b243a6bafb5d27'; \
+            BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u452b09.tar.gz'; \
             ;; \
         aarch64|arm64) \
             ESUM='69d39682c4a2fac294a9eaacbf62c26d3c8a2f9123f1b5d287498a5472c6b672'; \

--- a/dockerfiles/jdk8/rocky/is/Dockerfile
+++ b/dockerfiles/jdk8/rocky/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to Rocky Linux Docker image
 FROM rockylinux:8
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.27"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.28"
 
 # Update the system to the specific 8.10 version
 RUN dnf -y update && \
@@ -37,15 +37,15 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 RUN yum install -y tzdata openssl ca-certificates fontconfig gzip tar nc unzip wget \
     && yum clean all
 
-ENV JAVA_VERSION jdk8u362-b09
+ENV JAVA_VERSION jdk8u452-b09
 
 # Install JDK8
 RUN set -eux; \
     ARCH="$(objdump="$(command -v objdump)" && objdump --file-headers "$objdump" | awk -F '[:,]+[[:space:]]+' '$1 == "architecture" { print $2 }')"; \
         case "${ARCH}" in \
         amd64|i386:x86-64) \
-            ESUM='1486a792fb224611ce0cd0e83d4aacd3503b56698549f8e9a9f0a6ebb83bdba1'; \
-            BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u362-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u362b09.tar.gz'; \
+            ESUM='9448308a21841960a591b47927cf2d44fdc4c0533a5f8111a4b243a6bafb5d27'; \
+            BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u452b09.tar.gz'; \
             ;; \
         arm64|aarch64) \
             ESUM='9290a8beefd7a94f0eb030f62d402411a852100482b9c5b63714bacc57002c2a'; \

--- a/dockerfiles/jdk8/ubuntu/is/Dockerfile
+++ b/dockerfiles/jdk8/ubuntu/is/Dockerfile
@@ -20,7 +20,7 @@
 FROM ubuntu:24.04
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.27"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.28"
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
@@ -31,15 +31,15 @@ RUN apt-get update \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_VERSION jdk8u362-b09
+ENV JAVA_VERSION jdk8u452-b09
 
 #Install JDK8
 RUN set -eux; \
     ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in \
         amd64|x86_64) \
-            ESUM='1486a792fb224611ce0cd0e83d4aacd3503b56698549f8e9a9f0a6ebb83bdba1'; \
-            BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u362-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u362b09.tar.gz'; \
+            ESUM='9448308a21841960a591b47927cf2d44fdc4c0533a5f8111a4b243a6bafb5d27'; \
+            BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u452-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u452b09.tar.gz'; \
             ;; \
        *) \
             echo "Unsupported arch: ${ARCH}"; \

--- a/dockerfiles/rocky/is/Dockerfile
+++ b/dockerfiles/rocky/is/Dockerfile
@@ -19,7 +19,7 @@
 # set base Docker image to Rocky Linux Docker image
 FROM rockylinux:8
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.27"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.28"
 
 # Update the system to the specific 8.10 version
 RUN dnf -y update && \

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -20,7 +20,7 @@
 FROM ubuntu:24.04
 
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
-      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.27"
+      com.wso2.docker.source="https://github.com/wso2/docker-is/releases/tag/v5.11.0.28"
 
 #Install JDK Dependencies
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'


### PR DESCRIPTION
## Purpose
This pull request updates the JDK8 version used in all relevant Dockerfiles to `jdk8u452-b09` and updates associated binary URLs and checksums. It also bumps the release version to `v5.11.0.28` across all Dockerfiles and documentation. These changes ensure that all images use the latest JDK8 release and are consistent with the new version tag.

**JDK8 Version Upgrade:**

* Updated `JAVA_VERSION` environment variable to `jdk8u452-b09` in all JDK8 Dockerfiles, replacing the previous `jdk8u362-b09` value. [[1]](diffhunk://#diff-6ec94e677ad71f0c87401a1f0e72ce2fd85432c9d2b118e6e1e850e0bcee32ccL22-R29) [[2]](diffhunk://#diff-c8da0e4cadb4604e01c5a81f41063722f9cbd9fb8b6a986a256d022b19f14234L22-R37) [[3]](diffhunk://#diff-9b1c7d9c6eaf31b3315fdc20a4d17bbaca67423cc0ce85a0d3ed7a3910870765L40-R48) [[4]](diffhunk://#diff-6d34e95e3d1e946d9c942aed844135e31ec27cbfe30f5f3493e6eaf2e34c4a8eL34-R42)
* Updated JDK binary URLs and checksums (`ESUM` and `BINARY_URL`) to match the new JDK8 release in all JDK8 Dockerfiles. [[1]](diffhunk://#diff-6ec94e677ad71f0c87401a1f0e72ce2fd85432c9d2b118e6e1e850e0bcee32ccL50-R51) [[2]](diffhunk://#diff-c8da0e4cadb4604e01c5a81f41063722f9cbd9fb8b6a986a256d022b19f14234L22-R37) [[3]](diffhunk://#diff-9b1c7d9c6eaf31b3315fdc20a4d17bbaca67423cc0ce85a0d3ed7a3910870765L40-R48) [[4]](diffhunk://#diff-6d34e95e3d1e946d9c942aed844135e31ec27cbfe30f5f3493e6eaf2e34c4a8eL34-R42)

**Version Tag Bump:**

* Updated the release version to `v5.11.0.28` in all Dockerfile labels and documentation. [[1]](diffhunk://#diff-a498d0f18ce4069c4d21d0e71212ae3ec4009222726af266b72cc8e99af22d63L22-R22) [[2]](diffhunk://#diff-5e3b36dc781c192d62e5c6d7567e9b19e95cf60dda6fa21680c78252aa81c762L22-R22) [[3]](diffhunk://#diff-6ec94e677ad71f0c87401a1f0e72ce2fd85432c9d2b118e6e1e850e0bcee32ccL22-R29) [[4]](diffhunk://#diff-c8da0e4cadb4604e01c5a81f41063722f9cbd9fb8b6a986a256d022b19f14234L22-R37) [[5]](diffhunk://#diff-9b1c7d9c6eaf31b3315fdc20a4d17bbaca67423cc0ce85a0d3ed7a3910870765L22-R22) [[6]](diffhunk://#diff-6d34e95e3d1e946d9c942aed844135e31ec27cbfe30f5f3493e6eaf2e34c4a8eL23-R23) [[7]](diffhunk://#diff-9c9eec07926d01f199bd16046529cd701706e540453dfbd43fc619c211675599L22-R22) [[8]](diffhunk://#diff-27630637247b8a256d9327bf82e1112c169d25169b28c892536787238bc00bf0L23-R23) [[9]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R12)

**Documentation:**

* Added a new changelog entry for version `v5.11.0.28`, documenting the JDK8 version update.