### PR TITLE
[6.0.x] Add arm support for ubuntu image

### DIFF
--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -41,6 +41,10 @@ RUN set -eux; \
             ESUM='398a64bff002f0e3b0c01ecd24a1a32c83cb72a5255344219e9757d4ddd9f857'; \
             BINARY_URL='https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1%2B1/OpenJDK11U-jdk_x64_linux_hotspot_11.0.20.1_1.tar.gz'; \
             ;; \
+        aarch64|arm64) \
+            ESUM='69d39682c4a2fac294a9eaacbf62c26d3c8a2f9123f1b5d287498a5472c6b672'; \
+            BINARY_URL='https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.20.1%2B1/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.20.1_1.tar.gz'; \
+            ;; \
        *) \
             echo "Unsupported arch: ${ARCH}"; \
             exit 1; \


### PR DESCRIPTION
## Purpose

This pull request adds support for the `aarch64`/`arm64` architecture in the `dockerfiles/ubuntu/is/Dockerfile`, allowing the Docker build to use the correct OpenJDK binary for ARM-based systems.

Platform support:

* Added handling for `aarch64` and `arm64` architectures, including the correct OpenJDK 11 binary URL and checksum for ARM builds.