### PR TITLE
[7.2.0] Revert bsdtar changes

### DIFF
--- a/dockerfiles/jdk11/rocky/is/Dockerfile
+++ b/dockerfiles/jdk11/rocky/is/Dockerfile
@@ -34,7 +34,7 @@ RUN yum install -y glibc-langpack-en && \
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Install JDK Dependencies.
-RUN yum install -y tzdata openssl ca-certificates fontconfig gzip tar bsdtar nc unzip wget \
+RUN yum install -y tzdata openssl ca-certificates fontconfig gzip tar nc unzip wget \
     && yum clean all
 
 ENV JAVA_VERSION jdk-11.0.28+6
@@ -60,7 +60,7 @@ RUN set -eux; \
     echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
     mkdir -p /opt/java/openjdk; \
     cd /opt/java/openjdk; \
-    bsdtar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+    tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
     rm -rf /tmp/openjdk.tar.gz;
 
 ENV JAVA_HOME=/opt/java/openjdk \

--- a/dockerfiles/jdk17/rocky/is/Dockerfile
+++ b/dockerfiles/jdk17/rocky/is/Dockerfile
@@ -34,7 +34,7 @@ RUN yum install -y glibc-langpack-en && \
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Install JDK Dependencies.
-RUN yum install -y tzdata openssl ca-certificates fontconfig gzip tar bsdtar nc unzip wget \
+RUN yum install -y tzdata openssl ca-certificates fontconfig gzip tar nc unzip wget \
     && yum clean all
 
 ENV JAVA_VERSION jdk-17.0.16+8
@@ -60,7 +60,7 @@ RUN set -eux; \
     echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
     mkdir -p /opt/java/openjdk; \
     cd /opt/java/openjdk; \
-    bsdtar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+    tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
     rm -rf /tmp/openjdk.tar.gz;
 
 ENV JAVA_HOME=/opt/java/openjdk \

--- a/dockerfiles/rocky/is/Dockerfile
+++ b/dockerfiles/rocky/is/Dockerfile
@@ -34,7 +34,7 @@ RUN yum install -y glibc-langpack-en && \
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 # Install JDK Dependencies.
-RUN yum install -y tzdata openssl ca-certificates fontconfig gzip tar bsdtar nc unzip wget \
+RUN yum install -y tzdata openssl ca-certificates fontconfig gzip tar nc unzip wget \
     && yum clean all
 
 ENV JAVA_VERSION jdk-21.0.8+9
@@ -60,7 +60,7 @@ RUN set -eux; \
     echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
     mkdir -p /opt/java/openjdk; \
     cd /opt/java/openjdk; \
-    bsdtar -xf /tmp/openjdk.tar.gz --strip-components=1; \
+    tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
     rm -rf /tmp/openjdk.tar.gz;
 
 ENV JAVA_HOME=/opt/java/openjdk \


### PR DESCRIPTION
## Purpose

This pull request updates the Dockerfiles for the JDK 11, JDK 17, and JDK 21 Rocky Linux images to simplify the extraction process and remove an unnecessary dependency. The main changes are the removal of the `bsdtar` package and switching from `bsdtar` to `tar` for extracting the JDK archive.

Dependency cleanup:

* Removed `bsdtar` from the list of installed packages in `dockerfiles/jdk11/rocky/is/Dockerfile`, `dockerfiles/jdk17/rocky/is/Dockerfile`, and `dockerfiles/rocky/is/Dockerfile`. (`[[1]](diffhunk://#diff-170f7d7fad8650d73d148f93a01c6d13936441b11d51222245807664e6c31083L37-R37)`, `[[2]](diffhunk://#diff-ebb3b19cf2e309de51c5c1b7f76179d00f7ba05b335006a356a68124fd074724L37-R37)`, `[[3]](diffhunk://#diff-9c9eec07926d01f199bd16046529cd701706e540453dfbd43fc619c211675599L37-R37)`)

Build process simplification:

* Replaced the use of `bsdtar` with the standard `tar` command for extracting `openjdk.tar.gz` in all three Dockerfiles. (`[[1]](diffhunk://#diff-170f7d7fad8650d73d148f93a01c6d13936441b11d51222245807664e6c31083L63-R63)`, `[[2]](diffhunk://#diff-ebb3b19cf2e309de51c5c1b7f76179d00f7ba05b335006a356a68124fd074724L63-R63)`, `[[3]](diffhunk://#diff-9c9eec07926d01f199bd16046529cd701706e540453dfbd43fc619c211675599L63-R63)`)

