### PR TITLE
[7.2.x] Update registry reference

### DIFF
--- a/docker-compose/is/README.md
+++ b/docker-compose/is/README.md
@@ -7,7 +7,7 @@
  * In order to use Docker images with [WSO2 Updates](https://wso2.com/updates), you need an active [WSO2 Subscription](https://wso2.com/subscription).
    Otherwise, you can proceed with Docker images available at [DockerHub](https://hub.docker.com/u/wso2/), which are created using GA releases.<br><br>
  * If you wish to run the Docker Compose setup using Docker images built locally, build Docker images using Docker resources available from [here](../../dockerfiles/)
-   and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
+   and remove the `registry.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
    
 ## How to deploy
 

--- a/docker-compose/is/dockerfiles/is/Dockerfile
+++ b/docker-compose/is/dockerfiles/is/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to WSO2 Identity Server Docker image with latest WSO2 Updates
-FROM docker.wso2.com/wso2is:7.2.0.0
+FROM registry.wso2.com/wso2-is/is:7.2.0.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 
 # build arguments for external artifacts


### PR DESCRIPTION
## Purpose

This pull request updates references to the WSO2 Docker image registry to use the new `registry.wso2.com` domain instead of the old `docker.wso2.com` domain. This ensures that both documentation and Dockerfiles are aligned with the current image hosting location.

**Registry domain update:**

* Updated the Docker image source in `docker-compose/is/dockerfiles/is/Dockerfile` to use `registry.wso2.com/wso2-is/is:7.2.0.0` as the base image instead of `docker.wso2.com/wso2is:7.2.0.0`.
* Updated the instructions in `docker-compose/is/README.md` to mention removing the `registry.wso2.com/` prefix from the `image` name instead of `docker.wso2.com/`.

