### PR TITLE
[7.0.x] Update registry reference

### DIFF
--- a/docker-compose/is/README.md
+++ b/docker-compose/is/README.md
@@ -7,7 +7,7 @@
  * In order to use Docker images with [WSO2 Updates](https://wso2.com/updates), you need an active [WSO2 Subscription](https://wso2.com/subscription).
    Otherwise, you can proceed with Docker images available at [DockerHub](https://hub.docker.com/u/wso2/), which are created using GA releases.<br><br>
  * If you wish to run the Docker Compose setup using Docker images built locally, build Docker images using Docker resources available from [here](../../dockerfiles/)
-   and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
+   and remove the `registry.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
    
 ## How to deploy
 

--- a/docker-compose/is/dockerfiles/is/Dockerfile
+++ b/docker-compose/is/dockerfiles/is/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to WSO2 Identity Server Docker image with latest WSO2 Updates
-FROM docker.wso2.com/wso2is:7.0.0.0
+FROM registry.wso2.com/wso2-is/is:7.0.0.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 
 # build arguments for external artifacts


### PR DESCRIPTION
## Purpose

This pull request updates references to WSO2 Docker image registries to reflect a change from the old `docker.wso2.com` registry to the new `registry.wso2.com`. This ensures that both documentation and Dockerfiles use the correct image source for building and deploying WSO2 Identity Server.

**Image registry updates:**

* Updated the `FROM` image in `docker-compose/is/dockerfiles/is/Dockerfile` to use `registry.wso2.com/wso2-is/is:7.0.0.0` instead of `docker.wso2.com/wso2is:7.0.0.0`.
* Updated the documentation in `docker-compose/is/README.md` to instruct users to remove the `registry.wso2.com/` prefix (instead of `docker.wso2.com/`) when using locally built images.


