### PR TITLE
[5.11.x] Update registry reference

### DIFF
--- a/docker-compose/is/README.md
+++ b/docker-compose/is/README.md
@@ -7,7 +7,7 @@
  * In order to use Docker images with [WSO2 Updates](https://wso2.com/updates), you need an active [WSO2 Subscription](https://wso2.com/subscription).
    Otherwise, you can proceed with Docker images available at [DockerHub](https://hub.docker.com/u/wso2/), which are created using GA releases.<br><br>
  * If you wish to run the Docker Compose setup using Docker images built locally, build Docker images using Docker resources available from [here](../../dockerfiles/)
-   and remove the `docker.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
+   and remove the `registry.wso2.com/` prefix from the `image` name in the `docker-compose.yml`. <br><br>
    
 ## How to deploy
 

--- a/docker-compose/is/dockerfiles/is/Dockerfile
+++ b/docker-compose/is/dockerfiles/is/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to WSO2 Identity Server Docker image with latest WSO2 Updates
-FROM docker.wso2.com/wso2is:5.11.0.0
+FROM registry.wso2.com/wso2-is/is:5.11.0.0
 LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>"
 
 # build arguments for external artifacts


### PR DESCRIPTION
## Purpose

This pull request updates references to the WSO2 Docker image registry to ensure consistency with the latest registry naming conventions. The changes affect both documentation and Dockerfiles.

**Registry reference updates:**

* Updated the base image in `docker-compose/is/dockerfiles/is/Dockerfile` to use `registry.wso2.com/wso2-is/is:5.11.0.0` instead of the deprecated `docker.wso2.com/wso2is:5.11.0.0`.
* Updated instructions in `docker-compose/is/README.md` to remove the `registry.wso2.com/` prefix (previously `docker.wso2.com/`) from the `image` name when using locally built images, reflecting the new registry naming.
