### PR TITLE
Removing update tool files

### DIFF
--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -113,6 +113,10 @@ RUN \
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_darwin_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_windows_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.ps1 \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.sh \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip
 

--- a/dockerfiles/jdk11/alpine/is/Dockerfile
+++ b/dockerfiles/jdk11/alpine/is/Dockerfile
@@ -109,6 +109,10 @@ RUN \
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_darwin_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_windows_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.ps1 \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.sh \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip
 

--- a/dockerfiles/jdk11/rocky/is/Dockerfile
+++ b/dockerfiles/jdk11/rocky/is/Dockerfile
@@ -119,6 +119,10 @@ RUN \
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_darwin_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_windows_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.ps1 \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.sh \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip
 

--- a/dockerfiles/jdk11/ubuntu/is/Dockerfile
+++ b/dockerfiles/jdk11/ubuntu/is/Dockerfile
@@ -114,6 +114,10 @@ RUN \
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_darwin_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_windows_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.ps1 \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.sh \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip
 

--- a/dockerfiles/jdk17/alpine/is/Dockerfile
+++ b/dockerfiles/jdk17/alpine/is/Dockerfile
@@ -109,6 +109,10 @@ RUN \
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_darwin_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_windows_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.ps1 \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.sh \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip
 

--- a/dockerfiles/jdk17/rocky/is/Dockerfile
+++ b/dockerfiles/jdk17/rocky/is/Dockerfile
@@ -119,6 +119,10 @@ RUN \
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_darwin_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_windows_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.ps1 \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.sh \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip
 

--- a/dockerfiles/jdk17/ubuntu/is/Dockerfile
+++ b/dockerfiles/jdk17/ubuntu/is/Dockerfile
@@ -114,6 +114,10 @@ RUN \
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_darwin_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_windows_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.ps1 \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.sh \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip
 

--- a/dockerfiles/pqc/is/Dockerfile
+++ b/dockerfiles/pqc/is/Dockerfile
@@ -126,6 +126,10 @@ RUN \
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_darwin_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_windows_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.ps1 \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.sh \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip
 

--- a/dockerfiles/rocky/is/Dockerfile
+++ b/dockerfiles/rocky/is/Dockerfile
@@ -119,6 +119,10 @@ RUN \
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_darwin_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_windows_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.ps1 \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.sh \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip
 

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -114,6 +114,10 @@ RUN \
 RUN \
     wget -O ${WSO2_SERVER}.zip "${WSO2_SERVER_DIST_URL}" \
     && unzip -d ${USER_HOME} ${WSO2_SERVER}.zip \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_darwin_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/wso2update_windows_* \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.ps1 \
+    && rm -f ${WSO2_SERVER_HOME}/bin/update_tool_setup.sh \
     && chown wso2carbon:wso2 -R ${WSO2_SERVER_HOME} \
     && rm -f ${WSO2_SERVER}.zip
 


### PR DESCRIPTION
This pull request updates the Dockerfiles for multiple base images to remove unnecessary platform-specific update tool binaries and scripts after extracting the WSO2 server distribution. This helps reduce image size and eliminates files not needed in the containerized Linux environment.

The most important changes are:

**Removal of unnecessary update tool binaries and scripts:**

* All affected Dockerfiles now remove `wso2update_darwin_*`, `wso2update_windows_*`, `update_tool_setup.ps1`, and `update_tool_setup.sh` from the `${WSO2_SERVER_HOME}/bin/` directory after unzipping the WSO2 server package. [[1]](diffhunk://#diff-a498d0f18ce4069c4d21d0e71212ae3ec4009222726af266b72cc8e99af22d63R116-R119) [[2]](diffhunk://#diff-e826c13c4f3e8f871ab5ee67799d1b148eb4ce38db2b7cdbc0c8b1009cd8b1ffR112-R115) [[3]](diffhunk://#diff-170f7d7fad8650d73d148f93a01c6d13936441b11d51222245807664e6c31083R122-R125) [[4]](diffhunk://#diff-a3aa88e1f165a69942232ba30176bf0f79e9ed36956b547965a7526c7343979cR117-R120) [[5]](diffhunk://#diff-d7c8b092ea985893c60c51da32c629d81716e5c91938474f0476a1c5f6572baeR112-R115) [[6]](diffhunk://#diff-ebb3b19cf2e309de51c5c1b7f76179d00f7ba05b335006a356a68124fd074724R122-R125) [[7]](diffhunk://#diff-ca37a84e4ba6a540feeb8ea07841a7f362563c3c550a3664e4d5515e47f60b8eR117-R120) [[8]](diffhunk://#diff-8e23b62619f0c66ea8e7839aff789e6d389752317e17b06ee4b4a1577760f001R129-R132) [[9]](diffhunk://#diff-9c9eec07926d01f199bd16046529cd701706e540453dfbd43fc619c211675599R122-R125) [[10]](diffhunk://#diff-27630637247b8a256d9327bf82e1112c169d25169b28c892536787238bc00bf0R117-R120)

These changes ensure that only the necessary files for the Linux environment remain in the final Docker images, improving security and efficiency.