### PR TITLE
[7.2.x] Use exec to ensure JVM receives SIGTERM for graceful shutdown

### DIFF
--- a/dockerfiles/alpine/is/docker-entrypoint.sh
+++ b/dockerfiles/alpine/is/docker-entrypoint.sh
@@ -33,4 +33,4 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh -Djava.util.prefs.systemRoot=/home/wso2carbon/.java -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs "$@"
+exec ${WSO2_SERVER_HOME}/bin/wso2server.sh -Djava.util.prefs.systemRoot=/home/wso2carbon/.java -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs "$@"

--- a/dockerfiles/jdk11/alpine/is/docker-entrypoint.sh
+++ b/dockerfiles/jdk11/alpine/is/docker-entrypoint.sh
@@ -33,4 +33,4 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh -Djava.util.prefs.systemRoot=/home/wso2carbon/.java -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs "$@"
+exec ${WSO2_SERVER_HOME}/bin/wso2server.sh -Djava.util.prefs.systemRoot=/home/wso2carbon/.java -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs "$@"

--- a/dockerfiles/jdk11/rocky/is/docker-entrypoint.sh
+++ b/dockerfiles/jdk11/rocky/is/docker-entrypoint.sh
@@ -33,4 +33,4 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"
+exec ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/jdk11/ubuntu/is/docker-entrypoint.sh
+++ b/dockerfiles/jdk11/ubuntu/is/docker-entrypoint.sh
@@ -33,4 +33,4 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"
+exec ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/jdk17/alpine/is/docker-entrypoint.sh
+++ b/dockerfiles/jdk17/alpine/is/docker-entrypoint.sh
@@ -33,4 +33,4 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh -Djava.util.prefs.systemRoot=/home/wso2carbon/.java -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs "$@"
+exec ${WSO2_SERVER_HOME}/bin/wso2server.sh -Djava.util.prefs.systemRoot=/home/wso2carbon/.java -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs "$@"

--- a/dockerfiles/jdk17/rocky/is/docker-entrypoint.sh
+++ b/dockerfiles/jdk17/rocky/is/docker-entrypoint.sh
@@ -33,4 +33,4 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"
+exec ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/jdk17/ubuntu/is/docker-entrypoint.sh
+++ b/dockerfiles/jdk17/ubuntu/is/docker-entrypoint.sh
@@ -33,4 +33,4 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"
+exec ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/pqc/is/docker-entrypoint.sh
+++ b/dockerfiles/pqc/is/docker-entrypoint.sh
@@ -33,4 +33,4 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"
+exec ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/rocky/is/docker-entrypoint.sh
+++ b/dockerfiles/rocky/is/docker-entrypoint.sh
@@ -33,4 +33,4 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"
+exec ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/dockerfiles/ubuntu/is/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/is/docker-entrypoint.sh
@@ -33,4 +33,4 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"
+exec ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"


### PR DESCRIPTION
**Problem**

When deploying WSO2 Identity Server in a Docker container, the JVM does not receive SIGTERM on container stop, resulting in a forceful kill after the grace period with no graceful shutdown.

The root cause is in `docker-entrypoint.sh` — the startup script is launched via `sh`:

```sh
sh ${WSO2_SERVER_HOME}/bin/wso2server.sh -Djava.util.prefs.systemRoot=/home/wso2carbon/.java -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs "$@"
```

This makes the shell PID 1 inside the container. Since the shell does not forward signals to its children, SIGTERM sent by Docker on `docker stop` never reaches `wso2server.sh` or the JVM.

**Fix**

Change `sh` to `exec` in the last line of `docker-entrypoint.sh`:

```sh
exec ${WSO2_SERVER_HOME}/bin/wso2server.sh -Djava.util.prefs.systemRoot=/home/wso2carbon/.java -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs "$@"
```

`exec` replaces the shell process with `wso2server.sh`, ensuring signals are forwarded correctly down to the JVM.

**Verification**

1. Apply the fix and build a new image.
2. Run `ps -ef` inside the container — Java is now PID 1.
3. Run `docker stop` — graceful shutdown logs are now visible confirming the JVM received SIGTERM.

Public issue : https://github.com/wso2/product-is/issues/27711
