### PR TITLE
[7.3.x] Ensure JVM receives SIGTERM for graceful shutdown

### DIFF
--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -106,7 +106,7 @@ COPY --chown=wso2carbon:wso2 docker-entrypoint.sh ${USER_HOME}/
 # Install required packages.
 RUN \
     apk update \
-    && apk add --no-cache netcat-openbsd \
+    && apk add --no-cache netcat-openbsd bash \
     && apk add unzip \
     && apk add wget
 

--- a/dockerfiles/alpine/is/docker-entrypoint.sh
+++ b/dockerfiles/alpine/is/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------
 # Copyright 2021 WSO2, LLC. (http://wso2.com)
 #
@@ -32,5 +32,17 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 # Copy any artifact changes mounted to artifact_volume.
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+stop_handler() {
+  trap - SIGTERM SIGINT
+  echo "Stopping WSO2 gracefully..." >&2
+  sh "${WSO2_SERVER_HOME}/bin/wso2server.sh" stop || true
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh -Djava.util.prefs.systemRoot=/home/wso2carbon/.java -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs "$@"
+echo "Start WSO2 Carbon server" >&2
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh -Djava.util.prefs.systemRoot=/home/wso2carbon/.java -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs "$@" &
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/pqc/is/docker-entrypoint.sh
+++ b/dockerfiles/pqc/is/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------
 # Copyright 2021 WSO2, LLC. (http://wso2.com)
 #
@@ -32,5 +32,17 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 # Copy any artifact changes mounted to artifact_volume.
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+stop_handler() {
+  trap - SIGTERM SIGINT
+  echo "Stopping WSO2 gracefully..." >&2
+  sh "${WSO2_SERVER_HOME}/bin/wso2server.sh" stop || true
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"
+echo "Start WSO2 Carbon server" >&2
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@" &
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/rocky/is/docker-entrypoint.sh
+++ b/dockerfiles/rocky/is/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------
 # Copyright 2025 WSO2, LLC. (http://wso2.com)
 #
@@ -32,5 +32,17 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 # Copy any artifact changes mounted to artifact_volume.
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+stop_handler() {
+  trap - SIGTERM SIGINT
+  echo "Stopping WSO2 gracefully..." >&2
+  sh "${WSO2_SERVER_HOME}/bin/wso2server.sh" stop || true
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"
+echo "Start WSO2 Carbon server" >&2
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@" &
+server_pid=$!
+wait "${server_pid}"

--- a/dockerfiles/ubuntu/is/docker-entrypoint.sh
+++ b/dockerfiles/ubuntu/is/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ------------------------------------------------------------------------
 # Copyright 2021 WSO2, LLC. (http://wso2.com)
 #
@@ -32,5 +32,17 @@ test -d ${config_volume} && [ "$(ls -A ${config_volume})" ] && cp -RL ${config_v
 # Copy any artifact changes mounted to artifact_volume.
 test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
 
+stop_handler() {
+  trap - SIGTERM SIGINT
+  echo "Stopping WSO2 gracefully..." >&2
+  sh "${WSO2_SERVER_HOME}/bin/wso2server.sh" stop || true
+  wait "${server_pid}"
+}
+
+trap 'stop_handler' SIGTERM SIGINT
+
 # Start WSO2 Carbon server.
-sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"
+echo "Start WSO2 Carbon server" >&2
+sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@" &
+server_pid=$!
+wait "${server_pid}"


### PR DESCRIPTION
## Summary

When a WSO2 IS Docker container is stopped via `docker stop`, a SIGTERM signal is sent to PID 1. Previously, `docker-entrypoint.sh` used `#!/bin/sh` which meant the shell could not receive and forward SIGTERM to the JVM. This resulted in the JVM being forcefully killed after the grace period with no graceful shutdown.

## Root Cause

The `docker-entrypoint.sh` used `#!/bin/sh` (dash) which does not forward signals to child processes.

## Fix

This fix is modelled after how WSO2 API Manager already handles graceful shutdown in its `docker-entrypoint.sh`.

Changes to `docker-entrypoint.sh` across all variants (ubuntu, rocky, alpine, pqc, jdk11/ubuntu, jdk11/rocky, jdk17/ubuntu, jdk17/rocky):

1. Changed shebang from `#!/bin/sh` to `#!/bin/bash` — bash forwards SIGTERM to its child process group unlike dash.
2. Replaced the final `sh` line with a `stop_handler` trap pattern that:
   - Registers a SIGTERM/SIGINT trap
   - Backgrounds the server process and captures its PID
   - On SIGTERM, explicitly calls `wso2server.sh stop` to trigger graceful shutdown
   - Waits for the server process to fully exit before the container stops

For alpine variants, `bash` is also added to the `apk add` line in the Dockerfile since it is not installed by default.

Public issue : https://github.com/wso2/product-is/issues/27711
Porting fix from : [7.2.x] https://github.com/wso2/docker-is/pull/509