### PR TITLE
[6.0] Upgrade base OS packages to latest security versions at build time

### DIFF
--- a/dockerfiles/alpine/is/Dockerfile
+++ b/dockerfiles/alpine/is/Dockerfile
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------
 #
-# Copyright 2024 WSO2, LLC. (http://wso2.com)
+# Copyright 2024-2026 WSO2, LLC. (http://wso2.com)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,8 @@ LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' 
 
 # Install JDK Dependencies
-RUN apk add --no-cache tzdata musl-locales musl-locales-lang \
+RUN apk upgrade --no-cache \
+    && apk add --no-cache tzdata musl-locales musl-locales-lang \
     && rm -rf /var/cache/apk/*
 
 ENV JAVA_VERSION jdk-11.0.20.1+1

--- a/dockerfiles/ubuntu/is/Dockerfile
+++ b/dockerfiles/ubuntu/is/Dockerfile
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------
 #
-# Copyright 2024 WSO2, LLC. (http://wso2.com)
+# Copyright 2024-2026 WSO2, LLC. (http://wso2.com)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,8 @@ LABEL maintainer="WSO2 Docker Maintainers <dev@wso2.org>" \
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales \
+    && DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y --no-install-recommends \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata curl ca-certificates fontconfig locales \
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Purpose
$subject

This change ensures all OS-level packages in the Docker images are upgraded to their latest available versions at build time.